### PR TITLE
Switch to just one requirements.txt and use consistent package naming.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,0 @@
-sphinx>=3
-sphinx-copybutton
-furo
-myst_parser

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Sphinx>=3.0
 myst-parser
 furo
-sphinx_copybutton
+sphinx-copybutton


### PR DESCRIPTION
This is a docs-only repo so we don't need docs/requirements.txt. Also, use dashes in package names.