### PR TITLE
Add basic GitHub Actions workflow to test local-style docs build in CI

### DIFF
--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -1,0 +1,26 @@
+name: Test Build
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build-sphinx:
+    name: Build with Sphinx
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade -r requirements.txt
+
+      - name: Build docs
+        run: python -bb -X dev -W error -m sphinx -n -E -a -W --keep-going docs build

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -24,3 +24,6 @@ jobs:
 
       - name: Build docs
         run: python -bb -X dev -W error -m sphinx -n -E -a -W --keep-going docs build
+
+      - name: Check links
+        run: python -b -X dev -m sphinx -b linkcheck -W --keep-going docs build

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -23,7 +23,7 @@ jobs:
           python -m pip install --upgrade -r requirements.txt
 
       - name: Build docs
-        run: python -bb -X dev -W error -m sphinx -n -E -a -W --keep-going docs build
+        run: python -bb -X dev -W error -m sphinx --color -n -E -a -W --keep-going docs build
 
       - name: Check links
-        run: python -b -X dev -m sphinx -b linkcheck -W --keep-going docs build
+        run: python -b -X dev -m sphinx --color -b linkcheck -W --keep-going docs build


### PR DESCRIPTION
This might not actually kick off until merged upstream (at least as a branch), but as a complement to #28 , this builds the docs using GHA CIs using essentially the same setup as locally, in addition to RTD-hosted preview builds, but with strict options. This ensures that everything continues to work with a local config as well as RTD, allows us to catch warnings, deprecations, missing references and more, and in addition serves as a quick and effective check that nothing is too broken, particularly as RTD preview builds are not set up.