### PR TITLE
Work around CI failure caused by deprecation warnings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,7 @@ myst-parser
 furo
 sphinx-copybutton
 sphinx-autobuild
+
+# TODO remove docutils pin when this issue fixed:
+# https://github.com/executablebooks/MyST-Parser/issues/612
+docutils<0.19


### PR DESCRIPTION
The CI is broken, for example at https://github.com/python/docs-community/pull/61

```
Exception occurred:
  File "/opt/hostedtoolcache/Python/3.[10](https://github.com/python/docs-community/actions/runs/3181866677/jobs/5187105115#step:5:11).7/x64/lib/python3.10/site-packages/docutils/frontend.py", line 662, in __init__
    warnings.warn('The frontend.OptionParser class will be replaced '
DeprecationWarning: The frontend.OptionParser class will be replaced by a subclass of argparse.ArgumentParser in Docutils 0.21 or later.
The full traceback has been saved in /tmp/sphinx-err-27jjpvsq.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
reading sources... [  5%] community/community-guide                            
Error: Process completed with exit code 2.
```

Already reported upstream issue: https://github.com/executablebooks/MyST-Parser/issues/612

In the meantime, let's work around it by pinning to docutils < 0.19.