### PR TITLE
Fix CI: Temporarily ignore deprecation warnings from Sphinx

### DIFF
--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -23,7 +23,10 @@ jobs:
           python -m pip install --upgrade -r requirements.txt
 
       - name: Build docs
-        run: python -bb -X dev -W error -m sphinx --color -n -E -a -W --keep-going docs build
+        # Temporarily ignore deprecation warnings until fixed:
+        # 'DeprecationWarning: 'imghdr' is deprecated and slated for removal in Python 3.13'
+        # https://github.com/sphinx-doc/sphinx/issues/10440
+        run: python -bb -X dev -W error -W ignore::DeprecationWarning -m sphinx --color -n -E -a -W --keep-going docs build
 
       - name: Check links
         run: python -b -X dev -m sphinx --color -b linkcheck -W --keep-going docs build


### PR DESCRIPTION
Re: https://github.com/python/docs-community/pull/68#issuecomment-1311718620

Sphinx is [failing on the CI](https://github.com/hugovk/docs-community/actions/runs/3445416680/jobs/5749102789#step:5:1) because we're turning warnings into errors (`-W error`) and Sphinx is using imghdr, and triggering a deprecation warning: 

```
Run python -bb -X dev -W error -m sphinx --color -n -E -a -W --keep-going docs build
Running Sphinx v5.3.0

Exception occurred:
  File "/opt/hostedtoolcache/Python/3.11.0/x64/lib/python3.11/warnings.py", line 514, in _deprecated
    warn(msg, DeprecationWarning, stacklevel=3)
DeprecationWarning: 'imghdr' is deprecated and slated for removal in Python 3.13
The full traceback has been saved in /tmp/sphinx-err-tfj_[8](https://github.com/hugovk/docs-community/actions/runs/3445416680/jobs/5749102789#step:5:9)37y.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
```

Let's temporarily disable deprecation warnings until https://github.com/sphinx-doc/sphinx/issues/10440 is fixed.
