### PR TITLE
Add meeting notes from 2023-01 (January 2023)

### DIFF
--- a/docs/monthly-meeting/2023-01.md
+++ b/docs/monthly-meeting/2023-01.md
@@ -1,6 +1,5 @@
 # Documentation Community Team Meeting (January 2023)
 
-:::info
 - **Date:** 2023-01-09
 - **Time:** [20:00 UTC](https://arewemeetingyet.com/UTC/2023-01-09/20:00/Docs%20Meeting)
 - **This HackMD:** https://hackmd.io/@encukou/pydocswg1
@@ -9,10 +8,10 @@
 - **How to participate:**
   -  Go to [Google Meet](https://meet.google.com/dii-qrzf-wkw) and ask to be let in.
   -  To edit notes, click the “pencil” or “split view” button on the [HackMD document](https://hackmd.io/@encukou/pydocswg1). You need to log in (e.g. with a GitHub account).
-:::
 
 By participating in this meeting, you are agreeing to abide by and uphold the [PSF Code of Conduct](https://www.python.org/psf/codeofconduct/).
 Please take a second to read through it!
+
 
 ## Roll call
 
@@ -22,19 +21,20 @@ Please take a second to read through it!
 - Hugo van Kemenade `@hugovk`
 - C.A.M. Gerlach `@CAM-Gerlach`
 
+
 ## Quick updates - Introductions
 
 > 60 second updates on things you have been up to, questions you have, or developments you think people should know about. Please add yourself, and if you do not have an update to share, you can pass.
->
 
-- (Hugo) SEO improvements. Using Sphinx extension that generate images for every single page that we have. But it is too heavy for CPython docs (40 MBs and nearly 500 images), using matplotlib to do it, which is pretty heavy library. Contributors shouldn't need to be installing this additional library, so we need to find solutions. The extra SEO images should only be generated when publishing CPython docs, and not for building locally. There should be an option to do it.
+- (Hugo) SEO improvements. Using Sphinx extension that generate images for every single page that we have. But it is too heavy for CPython docs (40 MBs and nearly 500 images), using Matplotlib to do it, which is pretty heavy library. Contributors shouldn't need to be installing this additional library, so we need to find solutions. The extra SEO images should only be generated when publishing CPython docs, and not for building locally. There should be an option to do it.
   - Check with Ee re. the file sizes
 
 - (CAM) PR for PEPs PR templates submitted: [python/peps#2956](https://github.com/python/peps/pull/2956)
 
-
 - (CAM) What's New issues.
-  * [python/cpython#100734](https://github.com/python/cpython/issues/100734)     Syncing changelog/What's New between versions
+  * [python/cpython#100734](https://github.com/python/cpython/issues/100734)
+    Syncing changelog/What's New between versions
+
     * CAM will sync things manually for now, we might waant some automation in the future
     * Would be good to note the Git commands in the RM checklist (PEP 101)
 
@@ -43,8 +43,7 @@ Please take a second to read through it!
 
 > This is a place to make announcements (without a need for discussion). This is also a great place to give shout-outs to contributors! We'll read through these at the beginning of the meeting.
 
-* Mariatta will be giving a talk about "Contributing to Python" tomorrow, will cover Docs contribution for sure. https://www.meetup.com/indypy/events/289628025/
-
+* Mariatta will be giving [a talk about "Contributing to Python"](https://www.meetup.com/indypy/events/289628025/) tomorrow; will cover Docs contribution for sure.
 
 
 ## Discussion
@@ -54,16 +53,22 @@ Please take a second to read through it!
 *For and about the Community or Working Group*
 
 - Time for the meeting
-  - Let's alternate the Monday slot with another time, so other ppl can join?
+  - Let's alternate the Monday slot with another time, so other people can join?
   - This is probably not the best audience :)
 
-- Trouble installing Python: https://mail.python.org/archives/list/docs@python.org/thread/I7JDNUYWIZ3QVY33IDYWFKDTZMIPIVNS/
-  - https://docs.python.org/3/using/mac.html#running-scripts-with-a-gui
+
+### Python Project Documentation
+
+- [Trouble installing Python](https://mail.python.org/archives/list/docs@python.org/thread/I7JDNUYWIZ3QVY33IDYWFKDTZMIPIVNS/)
+  - [Running scripts with a GUI](https://docs.python.org/3/using/mac.html#running-scripts-with-a-gui)
 
 - The docs mailing list:
     - I'm referring to docs@python.org
-    - This is linked from docs.python.org from "report a bug" section https://docs.python.org/3/bugs.html#documentation-bugs
+    - This is [linked](https://docs.python.org/3/bugs.html#documentation-bugs) from docs.python.org from "report a bug" section
     - [python/devguide#1025](https://github.com/python/devguide/pull/1025)
+
+
+### Devguide, PEPs, workflow, etc.
 
 * Release cycle chart in the Devguide
   * Followup: @CAM-Gerlach opened devguide issues for adding the additional development phase transition dates [python/devguide#998](https://github.com/python/devguide/issues/998) & a table of individual minor versions [python/devguide#999](https://github.com/python/devguide/issues/999)
@@ -72,31 +77,9 @@ Please take a second to read through it!
 * [python/devguide#1020](https://github.com/python/devguide/issues/1020): Function signatures in docs (positional-only markers, defaults, `[]` syntax)
 
 
-- `:::info` in the notes
-
-### Python Project Documentation
-
-*Relating to `docs.python.org`, `peps.python.org`, `devguide.python.org`, etc.*
-
-* https://packaging.python.org/en/latest/glossary/
-  * @CAM-Gerlach to improve the glossary. It can then be linked or copied to CPython docs.
-
-### PEP Workflow
-
-* [PEP 1 rewrite?](https://discuss.python.org/t/21068/26)
-* Final PEPs and the canonical docs banner link
-* Status for PEP 659 and other obsolete PEPs?
-
-### Improve SEO for CPython docs
-
-* (Hugo) OpenGraph metadata PRs:
-
-  * Followup: tell Marc-André about use of logo without font
-  * PEPs: TODO
-
 ## Next meeting
 
-The docs team meets generally on the first Monday of every month.
+The docs team generally meets on the first Monday of every month.
 
 We have a recurring Google Calendar event for the meeting.
 Let Mariatta know your email address and she can invite you.

--- a/docs/monthly-meeting/2023-01.md
+++ b/docs/monthly-meeting/2023-01.md
@@ -1,0 +1,102 @@
+# Documentation Community Team Meeting (January 2023)
+
+:::info
+- **Date:** 2023-01-09
+- **Time:** [20:00 UTC](https://arewemeetingyet.com/UTC/2023-01-09/20:00/Docs%20Meeting)
+- **This HackMD:** https://hackmd.io/@encukou/pydocswg1
+- [**Discourse thread**](https://discuss.python.org/t/documentation-community-meeting-january-9/22039) (for January)
+- **Calendar event:** (send your e-mail to Mariatta for an invitation)
+- **How to participate:**
+  -  Go to [Google Meet](https://meet.google.com/dii-qrzf-wkw) and ask to be let in.
+  -  To edit notes, click the “pencil” or “split view” button on the [HackMD document](https://hackmd.io/@encukou/pydocswg1). You need to log in (e.g. with a GitHub account).
+:::
+
+By participating in this meeting, you are agreeing to abide by and uphold the [PSF Code of Conduct](https://www.python.org/psf/codeofconduct/).
+Please take a second to read through it!
+
+## Roll call
+
+- Petr Viktorin, `@encukou`
+- Jim DeLaHunt, `@JDLH` (a conflict in real life took him away for 20 minutes)
+- Mariatta `@mariatta`
+- Hugo van Kemenade `@hugovk`
+- C.A.M. Gerlach `@CAM-Gerlach`
+
+## Quick updates - Introductions
+
+> 60 second updates on things you have been up to, questions you have, or developments you think people should know about. Please add yourself, and if you do not have an update to share, you can pass.
+>
+
+- (Hugo) SEO improvements. Using Sphinx extension that generate images for every single page that we have. But it is too heavy for CPython docs (40 MBs and nearly 500 images), using matplotlib to do it, which is pretty heavy library. Contributors shouldn't need to be installing this additional library, so we need to find solutions. The extra SEO images should only be generated when publishing CPython docs, and not for building locally. There should be an option to do it.
+  - Check with Ee re. the file sizes
+
+- (CAM) PR for PEPs PR templates submitted: [python/peps#2956](https://github.com/python/peps/pull/2956)
+
+
+- (CAM) What's New issues.
+  * [python/cpython#100734](https://github.com/python/cpython/issues/100734)     Syncing changelog/What's New between versions
+    * CAM will sync things manually for now, we might waant some automation in the future
+    * Would be good to note the Git commands in the RM checklist (PEP 101)
+
+
+## Reports and celebrations
+
+> This is a place to make announcements (without a need for discussion). This is also a great place to give shout-outs to contributors! We'll read through these at the beginning of the meeting.
+
+* Mariatta will be giving a talk about "Contributing to Python" tomorrow, will cover Docs contribution for sure. https://www.meetup.com/indypy/events/289628025/
+
+
+
+## Discussion
+
+### 'Internal' items
+
+*For and about the Community or Working Group*
+
+- Time for the meeting
+  - Let's alternate the Monday slot with another time, so other ppl can join?
+  - This is probably not the best audience :)
+
+- Trouble installing Python: https://mail.python.org/archives/list/docs@python.org/thread/I7JDNUYWIZ3QVY33IDYWFKDTZMIPIVNS/
+  - https://docs.python.org/3/using/mac.html#running-scripts-with-a-gui
+
+- The docs mailing list:
+    - I'm referring to docs@python.org
+    - This is linked from docs.python.org from "report a bug" section https://docs.python.org/3/bugs.html#documentation-bugs
+    - [python/devguide#1025](https://github.com/python/devguide/pull/1025)
+
+* Release cycle chart in the Devguide
+  * Followup: @CAM-Gerlach opened devguide issues for adding the additional development phase transition dates [python/devguide#998](https://github.com/python/devguide/issues/998) & a table of individual minor versions [python/devguide#999](https://github.com/python/devguide/issues/999)
+  * Petr is (slowly) working on generating the chart by Python
+
+* [python/devguide#1020](https://github.com/python/devguide/issues/1020): Function signatures in docs (positional-only markers, defaults, `[]` syntax)
+
+
+- `:::info` in the notes
+
+### Python Project Documentation
+
+*Relating to `docs.python.org`, `peps.python.org`, `devguide.python.org`, etc.*
+
+* https://packaging.python.org/en/latest/glossary/
+  * @CAM-Gerlach to improve the glossary. It can then be linked or copied to CPython docs.
+
+### PEP Workflow
+
+* [PEP 1 rewrite?](https://discuss.python.org/t/21068/26)
+* Final PEPs and the canonical docs banner link
+* Status for PEP 659 and other obsolete PEPs?
+
+### Improve SEO for CPython docs
+
+* (Hugo) OpenGraph metadata PRs:
+
+  * Followup: tell Marc-André about use of logo without font
+  * PEPs: TODO
+
+## Next meeting
+
+The docs team meets generally on the first Monday of every month.
+
+We have a recurring Google Calendar event for the meeting.
+Let Mariatta know your email address and she can invite you.

--- a/docs/monthly-meeting/2023-01.md
+++ b/docs/monthly-meeting/2023-01.md
@@ -35,7 +35,7 @@ Please take a second to read through it!
   * [python/cpython#100734](https://github.com/python/cpython/issues/100734)
     Syncing changelog/What's New between versions
 
-    * CAM will sync things manually for now, we might waant some automation in the future
+    * CAM will sync things manually for now, we might want some automation in the future
     * Would be good to note the Git commands in the RM checklist (PEP 101)
 
 
@@ -60,7 +60,7 @@ Please take a second to read through it!
 ### Python Project Documentation
 
 - [Trouble installing Python](https://mail.python.org/archives/list/docs@python.org/thread/I7JDNUYWIZ3QVY33IDYWFKDTZMIPIVNS/)
-  - [Running scripts with a GUI](https://docs.python.org/3/using/mac.html#running-scripts-with-a-gui)
+    - [Running scripts with a GUI](https://docs.python.org/3/using/mac.html#running-scripts-with-a-gui)
 
 - The docs mailing list:
     - I'm referring to docs@python.org

--- a/docs/monthly-meeting/index.rst
+++ b/docs/monthly-meeting/index.rst
@@ -22,3 +22,4 @@ Monthly reports in reverse chronological order.
    Oct 2022 <2022-10.md>
    Nov 2022 <2022-11.md>
    Dec 2022 <2022-12.md>
+   Jan 2023 <2023-01.md>


### PR DESCRIPTION
Since I didn't see anyone else adding them, I figured I'd go ahead and do so. The meeting notes from January, removing the leftover bullet points we didn't get the chance to discuss, and with some light formatting cleanup (as a separate commit, for full transparency). I wasn't sure if I should add links to Petr's PR with the SVGs or updates on anything else, since that was well after the meeting.