### PR TITLE
Automatically edit PRs with link to RTD preview

### DIFF
--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -1,0 +1,16 @@
+name: Read the Docs PR preview
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  documentation-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: "docs-community"


### PR DESCRIPTION
Let's try this by RTD: https://github.com/readthedocs/actions/tree/v1/preview

> GitHub Action that automatically edits Pull Requests' descriptions with a link to documentation's preview on Read the Docs.

For example: 

* https://github.com/poliastro/poliastro/blob/main/.github/workflows/documentation-links.yaml
* ->
* https://github.com/poliastro/poliastro/pull/1613

![image](https://user-images.githubusercontent.com/1324225/221863621-79e376fe-d5c9-45f5-b6d9-fa9a3632b81f.png)
