### PR TITLE
Add meeting notes from the March 2023 meeting

### DIFF
--- a/docs/monthly-meeting/2023-03.md
+++ b/docs/monthly-meeting/2023-03.md
@@ -1,0 +1,109 @@
+# Documentation Community Team Meeting (March 2023)
+
+:::info
+- **Date:** 2023-03-06 
+- **Time:** [20:00 UTC](https://arewemeetingyet.com/UTC/2023-03-06/20:00/Docs%20Meeting) 
+- **This HackMD:** https://hackmd.io/@encukou/pydocswg1
+- [**Discourse thread**](https://discuss.python.org/t/documentation-community-meeting-march-6-2023/24293) (for March)
+- [**Meeting's reports**](https://docs-community.readthedocs.io/en/latest/monthly-meeting/index.html) (the latest one might be an [**unmerged PR**](https://github.com/python/docs-community/pulls))
+- **Calendar event:** (send your e-mail to Mariatta for an invitation)
+- **How to participate:**
+  -  Go to [Google Meet](https://meet.google.com/dii-qrzf-wkw) and ask to be let in.
+  -  To edit notes, click the “pencil” or “split view” button on the [HackMD document](https://hackmd.io/@encukou/pydocswg1). You need to log in (e.g. with a GitHub account).
+:::
+
+By participating in this meeting, you are agreeing to abide by and uphold the [PSF Code of Conduct](https://www.python.org/psf/codeofconduct/).
+Please take a second to read through it!
+
+## Roll call
+
+(Name / `@GitHubUsername`)
+
+- Petr Viktorin / `@encukou`
+- Ezio Melotti / `@ezio-melotti`
+- Ege Akman / `@egeakman`
+- C.A.M. Gerlach / `@CAM-Gerlach`
+- Ryan Duve / `@ryan-duve`
+- Paul Hoffman / `@paulehoffman`
+- Hugo van Kemenade / `@hugovk`
+- Pradyun Gedam / `pradyunsg`
+
+## Introductions
+
+> If there are any new people, we should do a round of introductions.
+
+
+## Reports and celebrations
+
+> 60 second updates on things you have been up to, questions you have, or developments you think people should know about. Please add yourself, and if you do not have an update to share, you can pass.
+> 
+
+> This is a place to make announcements (without a need for discussion). This is also a great place to give shout-outs to contributors! We'll read through these at the beginning of the meeting.
+
+* Hugo: Automatically edit PRs with link to RTD preview
+  * https://github.com/python/devguide/pull/1061
+  * https://github.com/python/docs-community/pull/74
+  * https://github.com/python/peps/pull/3031
+  * TODO: Hugo to cleanup the Netlify action so we can transfer to https://github.com/python
+
+* Hugo: Append a hash ?digest to CSS files for cache-busting
+  * https://github.com/python/devguide/pull/1054
+  * https://github.com/python/python-docs-theme/pull/108
+
+
+
+## Discussion
+
+* Netlify previews
+
+
+### 'Internal' items
+
+*For and about the Community or Working Group*
+
+- Overhaul Building the Documentation section for clarity
+  - [python/devguide#1038](https://github.com/python/devguide/pull/1038)
+  - merged
+
+- [python/devguide#1020](https://github.com/python/devguide/issues/1020): Function signatures in docs (positional-only markers, defaults, `[]` syntax)
+  - How discoverable is the `[]` syntax to today's devs?
+
+
+### Python Project Documentation
+
+*Relating to `docs.python.org`, `peps.python.org`, `devguide.python.org`, etc.*
+
+* Dark theme for docs.python.org
+  * (Hugo) PR looks ready to merge: https://github.com/python/python-docs-theme/pull/44#pullrequestreview-1314475876
+  * Preview: https://python-docs-theme-previews--44.org.readthedocs.build/en/44/
+  * TODO: Hugo open an issue to ask for a release with pending bugfixes, followed by another with dark theme for easy rollback if needed
+
+* [Lutra](https://pradyunsg.me/lutra/)! Improving the bus factor, accessibility and next steps?
+
+* Move [PEP 636 (Structural Pattern Matching: Tutorial)](https://peps.python.org/pep-0636/#composing-patterns) to main docs
+  * See [Discourse thread](https://discuss.python.org/t/is-there-a-good-writeup-talk-about-the-implementation-of-pep-634/21987/6)
+
+* [`concurrent.futures`](https://docs.python.org/3.12/library/concurrent.futures.html) reorgantization
+  * See [Diataxis website](https://diataxis.fr/) and [Diataxis workshop videos](https://discuss.python.org/t/recordings-available-for-python-docs-diataxis-workshop/19518) for more information on organization
+
+* Sphinx warnings on CI: [hugovk/cpython#43](https://github.com/hugovk/cpython/pull/43)
+  * Build on Petr's [python/cpython#21](https://github.com/encukou/cpython/pull/21)
+  * show Sphinx warnings in changed files, can't fail
+  * show Sphinx warnings in required-list (e.g. What's New in 3.12), can fail
+  * TODO: Hugo to PR this upstream
+
+
+### PEPs styling
+
+
+### PEP Workflow
+
+* Final PEPs and the canonical docs banner link: in PR [python/peps#2992](https://github.com/python/peps/pull/2992)
+* [PEP 1 rewrite?](https://discuss.python.org/t/21068/26)* Status for PEP 659 and other obsolete PEPs?
+
+## Next meeting
+
+The docs team generally meets on the first Monday of every month.
+
+We have a recurring Google Calendar event for the meeting.
+Let Mariatta know your email address and she can invite you.

--- a/docs/monthly-meeting/2023-03.md
+++ b/docs/monthly-meeting/2023-03.md
@@ -1,19 +1,18 @@
 # Documentation Community Team Meeting (March 2023)
 
-:::info
-- **Date:** 2023-03-06 
-- **Time:** [20:00 UTC](https://arewemeetingyet.com/UTC/2023-03-06/20:00/Docs%20Meeting) 
+- **Date:** 2023-03-06
+- **Time:** [20:00 UTC](https://arewemeetingyet.com/UTC/2023-03-06/20:00/Docs%20Meeting)
 - **This HackMD:** https://hackmd.io/@encukou/pydocswg1
 - [**Discourse thread**](https://discuss.python.org/t/documentation-community-meeting-march-6-2023/24293) (for March)
-- [**Meeting's reports**](https://docs-community.readthedocs.io/en/latest/monthly-meeting/index.html) (the latest one might be an [**unmerged PR**](https://github.com/python/docs-community/pulls))
+- [**Meeting reports**](https://docs-community.readthedocs.io/en/latest/monthly-meeting/index.html) (the latest one might be an [**unmerged PR**](https://github.com/python/docs-community/pulls))
 - **Calendar event:** (send your e-mail to Mariatta for an invitation)
 - **How to participate:**
   -  Go to [Google Meet](https://meet.google.com/dii-qrzf-wkw) and ask to be let in.
-  -  To edit notes, click the “pencil” or “split view” button on the [HackMD document](https://hackmd.io/@encukou/pydocswg1). You need to log in (e.g. with a GitHub account).
-:::
+  -  To edit notes, click the “pencil" or “split view” button on the [HackMD document](https://hackmd.io/@encukou/pydocswg1). You need to log in (e.g. with a GitHub account).
 
 By participating in this meeting, you are agreeing to abide by and uphold the [PSF Code of Conduct](https://www.python.org/psf/codeofconduct/).
 Please take a second to read through it!
+
 
 ## Roll call
 
@@ -28,28 +27,22 @@ Please take a second to read through it!
 - Hugo van Kemenade / `@hugovk`
 - Pradyun Gedam / `pradyunsg`
 
-## Introductions
-
-> If there are any new people, we should do a round of introductions.
-
 
 ## Reports and celebrations
 
 > 60 second updates on things you have been up to, questions you have, or developments you think people should know about. Please add yourself, and if you do not have an update to share, you can pass.
-> 
 
 > This is a place to make announcements (without a need for discussion). This is also a great place to give shout-outs to contributors! We'll read through these at the beginning of the meeting.
 
 * Hugo: Automatically edit PRs with link to RTD preview
-  * https://github.com/python/devguide/pull/1061
-  * https://github.com/python/docs-community/pull/74
-  * https://github.com/python/peps/pull/3031
-  * TODO: Hugo to cleanup the Netlify action so we can transfer to https://github.com/python
+  * [python/devguide#1061](https://github.com/python/devguide/pull/1061)
+  * [python/docs-community#74](https://github.com/python/docs-community/pull/74)
+  * [python/peps#3031](https://github.com/python/peps/pull/3031)
+  * TODO: Hugo to cleanup the Netlify action so we can transfer to the [Python org](https://github.com/python)
 
-* Hugo: Append a hash ?digest to CSS files for cache-busting
-  * https://github.com/python/devguide/pull/1054
-  * https://github.com/python/python-docs-theme/pull/108
-
+* Hugo: Append a hash `?digest` to CSS files for cache-busting
+  * [python/devguide#1054](https://github.com/python/devguide/pull/1054)
+  * [python/python-docs-theme#108](https://github.com/python/python-docs-theme/pull/108)
 
 
 ## Discussion
@@ -74,8 +67,8 @@ Please take a second to read through it!
 *Relating to `docs.python.org`, `peps.python.org`, `devguide.python.org`, etc.*
 
 * Dark theme for docs.python.org
-  * (Hugo) PR looks ready to merge: https://github.com/python/python-docs-theme/pull/44#pullrequestreview-1314475876
-  * Preview: https://python-docs-theme-previews--44.org.readthedocs.build/en/44/
+  * (Hugo) PR looks ready to merge: [python/python-docs-theme#44](https://github.com/python/python-docs-theme/pull/44#pullrequestreview-1314475876)
+  * [Preview](https://python-docs-theme-previews--44.org.readthedocs.build/en/44/)
   * TODO: Hugo open an issue to ask for a release with pending bugfixes, followed by another with dark theme for easy rollback if needed
 
 * [Lutra](https://pradyunsg.me/lutra/)! Improving the bus factor, accessibility and next steps?
@@ -83,7 +76,7 @@ Please take a second to read through it!
 * Move [PEP 636 (Structural Pattern Matching: Tutorial)](https://peps.python.org/pep-0636/#composing-patterns) to main docs
   * See [Discourse thread](https://discuss.python.org/t/is-there-a-good-writeup-talk-about-the-implementation-of-pep-634/21987/6)
 
-* [`concurrent.futures`](https://docs.python.org/3.12/library/concurrent.futures.html) reorgantization
+* [`concurrent.futures`](https://docs.python.org/3.12/library/concurrent.futures.html) reorganization
   * See [Diataxis website](https://diataxis.fr/) and [Diataxis workshop videos](https://discuss.python.org/t/recordings-available-for-python-docs-diataxis-workshop/19518) for more information on organization
 
 * Sphinx warnings on CI: [hugovk/cpython#43](https://github.com/hugovk/cpython/pull/43)
@@ -93,13 +86,12 @@ Please take a second to read through it!
   * TODO: Hugo to PR this upstream
 
 
-### PEPs styling
-
-
 ### PEP Workflow
 
 * Final PEPs and the canonical docs banner link: in PR [python/peps#2992](https://github.com/python/peps/pull/2992)
-* [PEP 1 rewrite?](https://discuss.python.org/t/21068/26)* Status for PEP 659 and other obsolete PEPs?
+* [PEP 1 rewrite?](https://discuss.python.org/t/21068/26)
+* Status for PEP 659 and other obsolete PEPs?
+
 
 ## Next meeting
 

--- a/docs/monthly-meeting/index.rst
+++ b/docs/monthly-meeting/index.rst
@@ -24,3 +24,4 @@ Monthly reports in reverse chronological order.
    Dec 2022 <2022-12.md>
    Jan 2023 <2023-01.md>
    Feb 2023 <2023-02.md>
+   Mar 2023 <2023-03.md>

--- a/docs/monthly-meeting/index.rst
+++ b/docs/monthly-meeting/index.rst
@@ -3,7 +3,7 @@
 Monthly Reports Archive
 =======================
 
-Current agenda: TBD
+`Current agenda <https://hackmd.io/@encukou/pydocswg1>`_
 
 Monthly reports in reverse chronological order.
 


### PR DESCRIPTION
Adds the meeting notes from the March 2023 meeting, with some minor textual cleanup to linkify, remove sections that weren't relevant, tweak formatting and fix a couple typos (in a separate commit for easy reviewability).

Also replaces `Current agenda: TBD` on the index page with a link to the current agenda on HackMd, and got the live agenda ready for the next meeting.

<!-- readthedocs-preview docs-community start -->
----
:books: Documentation preview :books:: https://docs-community--76.org.readthedocs.build/en/76/

<!-- readthedocs-preview docs-community end -->