### PR TITLE
Revert "Temporarily ignore deprecation warnings from Sphinx"

### DIFF
--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -23,10 +23,7 @@ jobs:
           python -m pip install --upgrade -r requirements.txt
 
       - name: Build docs
-        # Temporarily ignore deprecation warnings until fixed:
-        # 'DeprecationWarning: 'imghdr' is deprecated and slated for removal in Python 3.13'
-        # https://github.com/sphinx-doc/sphinx/issues/10440
-        run: python -bb -X dev -W error -W ignore::DeprecationWarning -m sphinx --color -n -E -a -W --keep-going docs build
+        run: python -bb -X dev -W error -m sphinx --color -n -E -a -W --keep-going docs build
 
       - name: Check links
         run: python -b -X dev -m sphinx --color -b linkcheck -W --keep-going docs build


### PR DESCRIPTION
This reverts commit 39ba1d65a7aa4e9115504dbaabd8cff6f4c07d02 (PR https://github.com/python/docs-community/pull/69) to fix https://github.com/python/docs-community/issues/70.

Sphinx [v6.2.0](https://github.com/sphinx-doc/sphinx/releases/tag/v6.2.0) no longer uses imghdr: https://github.com/sphinx-doc/sphinx/commit/a502e7523376e0344c1c9cc8a9d128143cd98b2d.

Re: https://github.com/sphinx-doc/sphinx/issues/10440#issuecomment-1556180835

<!-- readthedocs-preview docs-community start -->
----
:books: Documentation preview :books:: https://docs-community--79.org.readthedocs.build/en/79/

<!-- readthedocs-preview docs-community end -->