### PR TITLE
Add meeting notes from June

### DIFF
--- a/docs/monthly-meeting/2023-06.md
+++ b/docs/monthly-meeting/2023-06.md
@@ -33,16 +33,7 @@ Regrets:
 - Mariatta
 
 
-## Introductions
-
-> If there are any new people, we should do a round of introductions.
-
-
 ## Reports and celebrations
-
-> 60 second updates on things you have been up to, questions you have, or developments you think people should know about. Please add yourself, and if you do not have an update to share, you can pass.
-
-> This is a place to make announcements (without a need for discussion). This is also a great place to give shout-outs to contributors! We'll read through these at the beginning of the meeting.
 
 * [CAM and Erlend's PyCon US talk is now up](https://youtu.be/nMekFX2CDVk)
     * CAM also pressented a derived version at his local Huntsville Python Users Group (HSV.py)
@@ -51,96 +42,40 @@ Regrets:
 
 ## Discussion
 
-[PSF elections](https://discuss.python.org/t/psf-board-election-dates-for-2023): do 5h/month for Python? [Self-certify/re-self-certify to vote](https://docs.google.com/forms/d/e/1FAIpQLSfwWBGkzvkWDZrxW3up_M_B7qgt1IWZlx9KJ0ucLA5WJP1vfA/viewform)
-  * Re-do the certification for this year!
+* [PSF elections](https://discuss.python.org/t/psf-board-election-dates-for-2023): do 5h/month for Python? [Self-certify/re-self-certify to vote](https://docs.google.com/forms/d/e/1FAIpQLSfwWBGkzvkWDZrxW3up_M_B7qgt1IWZlx9KJ0ucLA5WJP1vfA/viewform)
+    * Re-do the certification for this year!
 
-Infra: stats for docs
-* [Demo](https://hugovk-cpython.readthedocs.io/en/plausible/)
-* [Dashboard](https://plausible.io/share/hugovk-cpython.readthedocs.io?auth=XDF9fK3EB2dEHCr4sC9hn)
-* Script in header: [hugovk/cpython#28b2355](https://github.com/hugovk/cpython/commit/28b23555030d58fdb52b74a547cc621c49690de0)
-* [More info](https://plausible.io/self-hosted-web-analytics)
+* Infra: stats for docs
+    * [Demo](https://hugovk-cpython.readthedocs.io/en/plausible/)
+    * [Dashboard](https://plausible.io/share/hugovk-cpython.readthedocs.io?auth=XDF9fK3EB2dEHCr4sC9hn)
+    * Script in header: [hugovk/cpython#28b2355](https://github.com/hugovk/cpython/commit/28b23555030d58fdb52b74a547cc621c49690de0)
+    * [More info](https://plausible.io/self-hosted-web-analytics)
 
-Dark theme is live on 3.12 and 3.13, should we deploy it to earlier releases?
-* [python/python-docs-theme#44 (comment)](https://github.com/python/python-docs-theme/pull/44#issuecomment-1571331235)
+* Dark theme is live on 3.12 and 3.13, should we deploy it to earlier releases?
+    * [python/python-docs-theme#44 (comment)](https://github.com/python/python-docs-theme/pull/44#issuecomment-1571331235)
 
-EuroPython documentation sprint:
-* Would it be a "good fit" for a sprint?
-* How can we organize it?
-  * Hugo will organize
-* Who will be there from the docs community?
-* Would a translation sprint be feasible?
+* EuroPython documentation sprint:
+    * Would it be a "good fit" for a sprint?
+    * How can we organize it?
+        * Hugo will organize
+    * Who will be there from the docs community?
+    * Would a translation sprint be feasible?
 
-Japanese translation
+* Japanese translation
 
-How to get started?
-- Find a shortcoming & open an issue for it
-- Find an open issue & ask for help:
-  - [Docs community issues](https://github.com/python/docs-community/issues)
-  - [Python issues](https://github.com/python/cpython/labels/docs)
+* How to get started?
+    * Find a shortcoming & open an issue for it
+    * Find an open issue & ask for help:
+        * [Docs community issues](https://github.com/python/docs-community/issues)
+        * [Python issues](https://github.com/python/cpython/labels/docs)
 
-Adding "how to teach this" section to PEPs
-- we don't update final PEPs
-- but, you can find the living docs (or create them) and improve that
+* Adding "how to teach this" section to PEPs
+    * we don't update final PEPs
+    * but, you can find the living docs (or create them) and improve that
 
-Daniele @ EuroPython
-- a workshop on docs organization at EuroPython
-- half hour of hacking on docs while people watch
-
-
-
-## Followups from last month(s)
-
-* Building images with [mermaid.js](https://mermaid.js.org/) / [mermaid-cli](https://github.com/mermaid-js/mermaid-cli).
-  - @tysonclugg is trying to put together docs on concurrency which would benefit from good diagrams
-  - Some other tool to explore?
-
-* [Ned] Best entry point to working on docs, for people newly interested in helping?
-    - we need clear onboarding
-    - do we have style guide?
-    - Cristian: In the python-docs-es team we have a page inside the docs (docs-ception) that teach the whole process https://python-docs-es.readthedocs.io/es/3.11/CONTRIBUTING.html
-    - how do we write such docs?
-        - HackMD or Google Docs
-    - Python Docs Community web page, https://docs-community.readthedocs.io/en/latest/
-        - source: github.com/python/docs-community . e.g. front page source: [docs-community/docs/index.rst](https://github.com/python/docs-community/blob/main/docs/index.rst)
-        - start having better landing page for Docs there
-    - The landing page should point to where the conversations happen, e.g. the Discourse server. For a group of translators, a Telegram group is the conversation place. A conversation place helps people support each other.
-- Docs Community Contributing Guide: https://docs-community.readthedocs.io/en/latest/community/contributing.html
-
-- Translation group
-    - how to coordinate with the wider translations group, share tips, etc
-    - Manuel: started 3 years ago: have a place to connect with other translators and resources
-    - Julien introduced the tools for translation.
-    - Create channel for translations
-    - Cristian: It also could be a good idea to have in the main Documentation page (that we will have soon) something like "Wanna help with a translation of these docs? check out this initiatives (list of languages here)
-    - Ezio: I already brought it up a couple of times, but it would be good to unify the translation infrastructure and tools (see e.g. https://github.com/python/python-docs-zh-tw/issues/399)
-
-
-
-### 'Internal' items
-
-*For and about the Community or Working Group*
-
-
-
-
-### Python Project Documentation
-
-*Relating to `docs.python.org`, `peps.python.org`, `devguide.python.org`, etc.*
-
-Followups from last month(s)?
-
-* [Lutra](https://pradyunsg.me/lutra/)! Improving the bus factor, accessibility and next steps?
-
-* Move [PEP 636 (Structural Pattern Matching: Tutorial)](https://peps.python.org/pep-0636) to main docs
-  * See [Discourse thread](https://discuss.python.org/t/is-there-a-good-writeup-talk-about-the-implementation-of-pep-634/21987/6)
-
-* [`concurrent.futures`](https://docs.python.org/3.12/library/concurrent.futures.html) reorgantization
-  * See [Diataxis website](https://diataxis.fr/) and [Diataxis workshop videos](https://discuss.python.org/t/recordings-available-for-python-docs-diataxis-workshop/19518) for more information on organization
-
-
-What can we ~~steal~~ learn from Rust docs?
-
-### PEP Workflow
+* Daniele @ EuroPython
+    * a workshop on docs organization at EuroPython
+    * half hour of hacking on docs while people watch
 
 
 

--- a/docs/monthly-meeting/2023-06.md
+++ b/docs/monthly-meeting/2023-06.md
@@ -1,0 +1,152 @@
+# Documentation Community Team Meeting (June 2023)
+
+- **Date:** 2023-06-05
+- **Time:** [19:00 UTC](https://arewemeetingyet.com/UTC/2023-06-05/19:00/Docs%20Meeting) 
+- **This HackMD:** https://hackmd.io/@encukou/pydocswg1
+- [**Discourse thread**](https://discuss.python.org/t/27334) (for June)
+- [**Meeting reports**](https://docs-community.readthedocs.io/en/latest/monthly-meeting/index.html) (the latest one might be an [**unmerged PR**](https://github.com/python/docs-community/pulls))
+- **Calendar event:** (send your e-mail to Mariatta for an invitation)
+- **How to participate:**
+  -  Go to [Google Meet](https://meet.google.com/dii-qrzf-wkw) and ask to be let in.
+  -  To edit notes, click the “pencil” or “split view” button on the [HackMD document](https://hackmd.io/@encukou/pydocswg1). You need to log in (e.g. with a GitHub account).
+
+By participating in this meeting, you are agreeing to abide by and uphold the [PSF Code of Conduct](https://www.python.org/psf/codeofconduct/).
+Please take a second to read through it!
+
+
+## Roll call
+
+(Name / `@GitHubUsername` / Discord if different)
+- Petr Viktorin / `@encukou`
+- Manuel Kaufmann / `@humitos`
+- Ege Akman / `@egeakman`
+- Daniele / `@DanieleProcida`
+- Ned / `@nedbat`
+- Yaa / `@YaaNuamah`
+- CAM / `@CAM-Gerlach` (everywhere)
+- Hugo / `@hugovk`
+- Bradley
+- Marcus / `@betteridiot`
+
+Regrets:
+- Jim DeLaHunt / `@JDLH` (Sorry, I have no deliverables to report to the group, and I am busy with another project this month.)
+- Mariatta
+
+
+## Introductions
+
+> If there are any new people, we should do a round of introductions.
+
+
+## Reports and celebrations
+
+> 60 second updates on things you have been up to, questions you have, or developments you think people should know about. Please add yourself, and if you do not have an update to share, you can pass.
+
+> This is a place to make announcements (without a need for discussion). This is also a great place to give shout-outs to contributors! We'll read through these at the beginning of the meeting.
+
+* [CAM and Erlend's PyCon US talk is now up](https://youtu.be/nMekFX2CDVk)
+    * CAM also pressented a derived version at his local Huntsville Python Users Group (HSV.py)
+
+* PEPs site updated for better readability and performance: [python/peps#3132](https://github.com/python/peps/pull/3132)
+
+## Discussion
+
+[PSF elections](https://discuss.python.org/t/psf-board-election-dates-for-2023): do 5h/month for Python? [Self-certify/re-self-certify to vote](https://docs.google.com/forms/d/e/1FAIpQLSfwWBGkzvkWDZrxW3up_M_B7qgt1IWZlx9KJ0ucLA5WJP1vfA/viewform)
+  * Re-do the certification for this year!
+
+Infra: stats for docs
+* [Demo](https://hugovk-cpython.readthedocs.io/en/plausible/)
+* [Dashboard](https://plausible.io/share/hugovk-cpython.readthedocs.io?auth=XDF9fK3EB2dEHCr4sC9hn)
+* Script in header: [hugovk/cpython#28b2355](https://github.com/hugovk/cpython/commit/28b23555030d58fdb52b74a547cc621c49690de0)
+* [More info](https://plausible.io/self-hosted-web-analytics)
+
+Dark theme is live on 3.12 and 3.13, should we deploy it to earlier releases?
+* [python/python-docs-theme#44 (comment)](https://github.com/python/python-docs-theme/pull/44#issuecomment-1571331235)
+
+EuroPython documentation sprint:
+* Would it be a "good fit" for a sprint?
+* How can we organize it?
+  * Hugo will organize
+* Who will be there from the docs community?
+* Would a translation sprint be feasible?
+
+Japanese translation
+
+How to get started?
+- Find a shortcoming & open an issue for it
+- Find an open issue & ask for help:
+  - [Docs community issues](https://github.com/python/docs-community/issues)
+  - [Python issues](https://github.com/python/cpython/labels/docs)
+
+Adding "how to teach this" section to PEPs
+- we don't update final PEPs
+- but, you can find the living docs (or create them) and improve that
+
+Daniele @ EuroPython
+- a workshop on docs organization at EuroPython
+- half hour of hacking on docs while people watch
+
+
+
+## Followups from last month(s)
+
+* Building images with [mermaid.js](https://mermaid.js.org/) / [mermaid-cli](https://github.com/mermaid-js/mermaid-cli).
+  - @tysonclugg is trying to put together docs on concurrency which would benefit from good diagrams
+  - Some other tool to explore?
+
+* [Ned] Best entry point to working on docs, for people newly interested in helping?
+    - we need clear onboarding
+    - do we have style guide?
+    - Cristian: In the python-docs-es team we have a page inside the docs (docs-ception) that teach the whole process https://python-docs-es.readthedocs.io/es/3.11/CONTRIBUTING.html
+    - how do we write such docs?
+        - HackMD or Google Docs
+    - Python Docs Community web page, https://docs-community.readthedocs.io/en/latest/
+        - source: github.com/python/docs-community . e.g. front page source: [docs-community/docs/index.rst](https://github.com/python/docs-community/blob/main/docs/index.rst)
+        - start having better landing page for Docs there
+    - The landing page should point to where the conversations happen, e.g. the Discourse server. For a group of translators, a Telegram group is the conversation place. A conversation place helps people support each other.
+- Docs Community Contributing Guide: https://docs-community.readthedocs.io/en/latest/community/contributing.html
+
+- Translation group
+    - how to coordinate with the wider translations group, share tips, etc
+    - Manuel: started 3 years ago: have a place to connect with other translators and resources
+    - Julien introduced the tools for translation.
+    - Create channel for translations
+    - Cristian: It also could be a good idea to have in the main Documentation page (that we will have soon) something like "Wanna help with a translation of these docs? check out this initiatives (list of languages here)
+    - Ezio: I already brought it up a couple of times, but it would be good to unify the translation infrastructure and tools (see e.g. https://github.com/python/python-docs-zh-tw/issues/399)
+
+
+
+### 'Internal' items
+
+*For and about the Community or Working Group*
+
+
+
+
+### Python Project Documentation
+
+*Relating to `docs.python.org`, `peps.python.org`, `devguide.python.org`, etc.*
+
+Followups from last month(s)?
+
+* [Lutra](https://pradyunsg.me/lutra/)! Improving the bus factor, accessibility and next steps?
+
+* Move [PEP 636 (Structural Pattern Matching: Tutorial)](https://peps.python.org/pep-0636) to main docs
+  * See [Discourse thread](https://discuss.python.org/t/is-there-a-good-writeup-talk-about-the-implementation-of-pep-634/21987/6)
+
+* [`concurrent.futures`](https://docs.python.org/3.12/library/concurrent.futures.html) reorgantization
+  * See [Diataxis website](https://diataxis.fr/) and [Diataxis workshop videos](https://discuss.python.org/t/recordings-available-for-python-docs-diataxis-workshop/19518) for more information on organization
+
+
+What can we ~~steal~~ learn from Rust docs?
+
+### PEP Workflow
+
+
+
+## Next meeting
+
+The docs team generally meets on the first Monday of every month.
+
+We have a recurring Google Calendar event for the meeting.
+Let Mariatta know your email address and she can invite you.

--- a/docs/monthly-meeting/index.rst
+++ b/docs/monthly-meeting/index.rst
@@ -27,3 +27,4 @@ Monthly reports in reverse chronological order.
    Mar 2023 <2023-03.md>
    Apr 2023 <2023-04.md>
    May 2023 <2023-05.md>
+   Jun 2023 <2023-06.md>


### PR DESCRIPTION
These are the notes from the June meeting of the working group. Lines 3 & 13 removed as per @encukou's suggestion. 

<!-- readthedocs-preview docs-community start -->
----
:books: Documentation preview :books:: https://docs-community--81.org.readthedocs.build/en/81/

<!-- readthedocs-preview docs-community end -->