### PR TITLE
Add option to ignore URLs and patterns when link checking

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,3 +36,14 @@ needs_sphinx = "4.0"
 
 # The theme to use for HTML pages
 html_theme = "furo"
+
+
+# Options for the linkcheck builder
+# =================================
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-the-linkcheck-builder
+
+# A list of patterns to ignore when checking for broken links
+linkcheck_ignore = [
+    "https:\/\/[a-zA-Z0-9.-]+\.org\.readthedocs\.build\/[a-zA-Z0-9.-]+\/[a-zA-Z0-9.-]+\/",  # RTD preview builds
+    "https://plausible.io/share/hugovk-cpython.readthedocs.io?auth=XDF9fK3EB2dEHCr4sC9hn",  # Deleted Plausible link
+]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,6 +44,6 @@ html_theme = "furo"
 
 # A list of patterns to ignore when checking for broken links
 linkcheck_ignore = [
-    "https:\/\/[a-zA-Z0-9.-]+\.org\.readthedocs\.build\/[a-zA-Z0-9.-]+\/[a-zA-Z0-9.-]+\/",  # RTD preview builds
-    "https://plausible.io/share/hugovk-cpython.readthedocs.io?auth=XDF9fK3EB2dEHCr4sC9hn",  # Deleted Plausible link
+    r"https://[a-zA-Z0-9.-]+\.org\.readthedocs\.build/[a-zA-Z0-9.-]+/[a-zA-Z0-9.-]+/",  # RTD preview builds
+    r"https://plausible\.io/share/hugovk-cpython\.readthedocs\.io\?auth=XDF9fK3EB2dEHCr4sC9hn",  # Deleted Plausible page
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,6 +44,8 @@ html_theme = "furo"
 
 # A list of patterns to ignore when checking for broken links
 linkcheck_ignore = [
-    r"https://[a-zA-Z0-9.-]+\.org\.readthedocs\.build/[a-zA-Z0-9.-]+/[a-zA-Z0-9.-]+/",  # RTD preview builds
-    r"https://plausible\.io/share/hugovk-cpython\.readthedocs\.io\?auth=XDF9fK3EB2dEHCr4sC9hn",  # Deleted Plausible page
+    # RTD preview builds:
+    r"https://[a-zA-Z0-9.-]+\.org\.readthedocs\.build/[a-zA-Z0-9.-]+/[a-zA-Z0-9.-]+/",
+    # Deleted Plausible page:
+    r"https://plausible\.io/share/hugovk-cpython\.readthedocs\.io\?auth=XDF9fK3EB2dEHCr4sC9hn",
 ]


### PR DESCRIPTION
Ignore:
* RTD preview links,
* The deleted Plausible page in the 2023-06 meeting.

cc: @hugovk

<!-- readthedocs-preview docs-community start -->
----
:books: Documentation preview :books:: https://docs-community--83.org.readthedocs.build/en/83/

<!-- readthedocs-preview docs-community end -->