### PR TITLE
Add CI section (autoupdate) to pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,3 @@
-ci:
-  autofix_prs: false
-  autoupdate_schedule: monthly
-
 repos:
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 23.12.1
@@ -21,3 +17,7 @@ repos:
     rev: v0.9.1
     hooks:
       - id: sphinx-lint
+
+ci:
+  autofix_prs: false
+  autoupdate_schedule: monthly

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,5 +19,4 @@ repos:
       - id: sphinx-lint
 
 ci:
-  autofix_prs: false
-  autoupdate_schedule: monthly
+  autoupdate_schedule: quarterly

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,11 @@
+ci:
+  autofix_prs: false
+  autoupdate_branch: "pre-commit-autoupdate"
+  autoupdate_schedule: monthly
+
 repos:
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.12.0
+    rev: 23.12.1
     hooks:
       - id: black
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,5 @@
 ci:
   autofix_prs: false
-  autoupdate_branch: "pre-commit-autoupdate"
   autoupdate_schedule: monthly
 
 repos:


### PR DESCRIPTION
If someone can enable [pre-commit.ci](https://pre-commit.ci), we could get monthly or weekly auto updates. I don't have write access here, so I can't enable it.

See also: https://github.com/python/docs-community/pull/90#pullrequestreview-1689194338

<!-- readthedocs-preview docs-community start -->
----
📚 Documentation preview 📚: https://docs-community--95.org.readthedocs.build/en/95/

<!-- readthedocs-preview docs-community end -->