### PR TITLE
Update docs and add editorial board page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Python Documentation Community
 
 [![Documentation Status](https://readthedocs.org/projects/docs-community/badge/?version=latest)](https://docs-community.readthedocs.io/en/latest/?badge=latest)
+![Discourse](https://img.shields.io/badge/discourse-chat-brightgreen)
 
 ![pep-0732-concentric.drawio.svg](pep-0732-concentric.drawio.svg)
 
@@ -14,7 +15,7 @@
    Repo: [python/docs-community](https://github.com/python/docs-community)
 3. Users of Python Documentation
 
-This repo serves as documentation for the docs-community.
+This repo serves as documentation for the Documentation Community Group.
 
 For example, to find out more about us and what we do, [read the docs](https://docs-community.readthedocs.io/en/latest/).
 
@@ -40,6 +41,7 @@ For example, to find out more about us and what we do, [read the docs](https://d
    ```console
    python -m pip install -r requirements.txt
    ```
+
 5. Build the docs, open them in your browser and update whenever changes are made
 
    ```console

--- a/docs/community/community-guide.md
+++ b/docs/community/community-guide.md
@@ -12,7 +12,7 @@ a quick list to get you started.
 - [devguide](https://devguide.python.org)
 - [docs](https://docs.python.org)
 - python_docs_theme
-- discourse channel
+- [discourse category](https://discuss.python.org/c/documentation/26)
 - discord channel
 
 ### General information about communication channels

--- a/docs/community/community-guide.md
+++ b/docs/community/community-guide.md
@@ -8,11 +8,12 @@ team!
 
 There are a few resources that are particularly useful for team members. Here's
 a quick list to get you started.
-- devguide
-- docs
+
+- [devguide](https://devguide.python.org)
+- [docs](https://docs.python.org)
 - python_docs_theme
 - discourse channel
-
+- discord channel
 
 ### General information about communication channels
 
@@ -20,8 +21,12 @@ We are trying to organize our discussions in order to help both contributors and
 maintainers find and choose the right communication channels and have a positive experience :-)
 
 In this respect, we are using:
-1. [BPO](https://bugs.python.org) and GitHub issues for specific discussions related to changing a repository's content. This is determined by doc project.
+
+1. GitHub issues for specific discussions related to changing a repository's content.
 2. The [Discourse forum](http://discuss.python.org/) for general discussions, support
 questions, or just as a place where we can inspire each other.
 
 ## How can I help?
+
+Read the devguide's section on documentation.
+Visit the Python repo's GitHub issues and look for issues tagged with `docs`.

--- a/docs/community/community-guide.md
+++ b/docs/community/community-guide.md
@@ -29,4 +29,4 @@ questions, or just as a place where we can inspire each other.
 ## How can I help?
 
 Read the devguide's section on documentation.
-Visit the Python repo's GitHub issues and look for issues tagged with `docs`.
+Visit the Python repo's GitHub issues and look for [issues tagged with "docs"](https://github.com/python/cpython/labels/docs).

--- a/docs/community/community-guide.md
+++ b/docs/community/community-guide.md
@@ -13,7 +13,7 @@ a quick list to get you started.
 - [docs](https://docs.python.org)
 - python_docs_theme
 - [discourse category](https://discuss.python.org/c/documentation/26)
-- discord channel
+- Discord server
 
 ### General information about communication channels
 

--- a/docs/community/community-guide.md
+++ b/docs/community/community-guide.md
@@ -23,7 +23,7 @@ maintainers find and choose the right communication channels and have a positive
 In this respect, we are using:
 
 1. GitHub issues for specific discussions related to changing a repository's content.
-2. The [Discourse forum](http://discuss.python.org/) for general discussions, support
+2. The [Discourse forum](https://discuss.python.org/c/documentation/26) for general discussions, support
 questions, or just as a place where we can inspire each other.
 
 ## How can I help?

--- a/docs/community/index.rst
+++ b/docs/community/index.rst
@@ -18,4 +18,3 @@ The Documentation Community Team has a Code of Conduct
     contributing
     community-guide
     skills
-    team

--- a/docs/community/skills.md
+++ b/docs/community/skills.md
@@ -4,12 +4,9 @@
 
 The short answer to this question is: follow your interests :-)
 
-## A few general ways to help out
-
-
-### Python-specific knowledge
-
-- **Code structure of the docs repository**
+The [Python Developer's Guide documentation](https://devguide.python.org/documentation) section is a good place to start.
+It's a comprehensive guide to the Python documentation and the tools we use to build it.
+It's a good idea to read through the guide to get a sense of the tools and processes we use.
 
 ## A note on complexity of tasks
 
@@ -17,11 +14,3 @@ Depth/expertise required for certain kinds of tasks can be hard to nail down and
 all obvious. If you'd like to make a contribution and you're not sure where to start,
 a good rule of thumb is to reach out to another team member to help
 you scope the work you'd like to do, and to set expectations.
-
-## Links
-
-
-
-## Resources for Learning
-
-In this section, we gather some introductory materials for learning the aforementioned tools.

--- a/docs/community/team.rst
+++ b/docs/community/team.rst
@@ -1,3 +1,7 @@
+:orphan:
+
+.. This page is retained solely for existing links.
+
 .. _doc_team:
 
 ==================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,7 @@ author = "Documentation Team"
 # A list of strings that are module names of Sphinx extensions
 extensions = [
     "sphinx_copybutton",
+    "sphinx.ext.intersphinx",
     "myst_parser",
 ]
 
@@ -29,6 +30,13 @@ exclude_patterns = [
 # Minimum Sphinx version as a string
 needs_sphinx = "4.0"
 
+# Intersphinx configuration
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3/', None),
+    'devguide': ('https://devguide.python.org/', None),
+    'pep': ('https://peps.python.org/', None),
+}
+intersphinx_disabled_reftypes = []
 
 # Options for HTML output
 # =======================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,9 +32,9 @@ needs_sphinx = "4.0"
 
 # Intersphinx configuration
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3/', None),
-    'devguide': ('https://devguide.python.org/', None),
-    'pep': ('https://peps.python.org/', None),
+    "python": ("https://docs.python.org/3/", None),
+    "devguide": ("https://devguide.python.org/", None),
+    "pep": ("https://peps.python.org/", None),
 }
 intersphinx_disabled_reftypes = []
 

--- a/docs/editorial-board/index.rst
+++ b/docs/editorial-board/index.rst
@@ -4,8 +4,7 @@
 Editorial Board
 ===============
 
-The acceptance of `PEP 732 <https://peps.python.org/pep-0732/>`_ established
-the Python Documentation Editorial Board.
+The acceptance of :pep:`732` established the Python Documentation Editorial Board.
 
 Monthly Editorial Board Meetings
 ================================

--- a/docs/editorial-board/index.rst
+++ b/docs/editorial-board/index.rst
@@ -11,7 +11,7 @@ Monthly Editorial Board Meetings
 
 The Editorial Board's private meetings are held monthly on the second Monday
 at 1:30pm Pacific.
-After each meeting the Editorial Board will post a summary in the 
+After each meeting the Editorial Board will post a summary in the
 `python/editorial-board repository <https://github.com/python/editorial-board>`_.
 
 Working with the Editorial Board

--- a/docs/editorial-board/index.rst
+++ b/docs/editorial-board/index.rst
@@ -1,0 +1,25 @@
+.. _eb_index:
+
+===============
+Editorial Board
+===============
+
+The acceptance of `PEP 732 <https://peps.python.org/pep-0732/>`_ established
+the Python Documentation Editorial Board.
+
+Monthly Editorial Board Meetings
+================================
+
+The Editorial Board's private meetings are held monthly on the second Monday
+at 1:30pm Pacific.
+After each meeting the Editorial Board will post a summary in the 
+`python/editorial-board repository <https://github.com/python/editorial-board>`_.
+
+Working with the Editorial Board
+================================
+
+If you have a general documentation request or question, please use the
+`Documentation category in Discourse <https://discuss.python.org/c/documentation/26>`_.
+
+If you need Editorial Board assistance, please file an
+`issue on the editorial-board repo <https://github.com/python/editorial-board/issues/new/choose>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,18 +2,18 @@
 Python Documentation Community
 ==============================
 
-The following pages contain information about the documentation workgroup,
-the documentation community team and
-community team, resources for community members, and workgroup practices for
-governance and planning.
+These pages explain the Python Documentation Community and its processes.
 
 .. toctree::
    :maxdepth: 2
 
-   workgroup/index
    community/index
    monthly-meeting/index
-   GitHub repository <https://github.com/python/docs-community>
+   editorial-board/index
+   GitHub docs-community <https://github.com/python/docs-community>
+   GitHub editorial-board <https://github.com/python/editorial-board>
+   Dev Guide - Documentation <https://devguide.python.org/documentation/>
+   Python Documentation <https://docs.python.org>
 
 Why have this repo?
 ===================
@@ -28,8 +28,6 @@ needed. The repo contains:
 
 - team meeting agendas and archives
 - direction and action plans
-- communication and culture of respectful teamwork
-- recognitions and team celebrations
 
 Code of Conduct
 ===============

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,8 +12,8 @@ These pages explain the Python Documentation Community and its processes.
    editorial-board/index
    GitHub docs-community <https://github.com/python/docs-community>
    GitHub editorial-board <https://github.com/python/editorial-board>
-   Dev Guide - Documentation <https://devguide.python.org/documentation/>
-   Python Documentation <https://docs.python.org>
+   Dev Guide <https://devguide.python.org/documentation/>
+   Python Docs <https://docs.python.org>
 
 Why have this repo?
 ===================

--- a/docs/monthly-meeting/index.rst
+++ b/docs/monthly-meeting/index.rst
@@ -5,7 +5,7 @@ Monthly Reports Archive
 
 `Current agenda <https://hackmd.io/@encukou/pydocswg1>`_
 
-Monthly reports in reverse chronological order.
+Monthly reports in chronological order.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/workgroup/adding-members.rst
+++ b/docs/workgroup/adding-members.rst
@@ -1,3 +1,7 @@
+:orphan:
+
+.. This page is retained solely for existing links.
+
 ===========================================
 Adding and onboarding new workgroup members
 ===========================================

--- a/docs/workgroup/index.rst
+++ b/docs/workgroup/index.rst
@@ -1,3 +1,7 @@
+:orphan:
+
+.. This page is retained solely for existing links.
+
 .. _governance-index:
 
 ==============

--- a/docs/workgroup/milestones.rst
+++ b/docs/workgroup/milestones.rst
@@ -1,3 +1,7 @@
+:orphan:
+
+.. This page is retained solely for existing links.
+
 =======================
 Milestones and roadmaps
 =======================

--- a/docs/workgroup/workgroup_charter.rst
+++ b/docs/workgroup/workgroup_charter.rst
@@ -1,3 +1,7 @@
+:orphan:
+
+.. This page is retained solely for existing links.
+
 ===============================
 CPython Documentation Workgroup
 ===============================


### PR DESCRIPTION
This PR:
- adds an editorial board page
- orphans old pages
- edits pages to bring more up to date
- adds intersphinx targets
- updates readme

Closes #100 

<!-- readthedocs-preview docs-community start -->
----
📚 Documentation preview 📚: https://docs-community--103.org.readthedocs.build/en/103/

<!-- readthedocs-preview docs-community end -->