### PR TITLE
Add Dependabot to keep GitHub Actions up-to-date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: monthly
+    assignees:
+      - "ezio-melotti"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python 3
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
           cache: "pip"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.12.1
+    rev: 24.1.1
     hooks:
       - id: black
 
@@ -17,6 +17,11 @@ repos:
     rev: v0.9.1
     hooks:
       - id: sphinx-lint
+
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes
 
 ci:
   autoupdate_schedule: quarterly


### PR DESCRIPTION
Similar to https://github.com/python/python-docs-theme/pull/170.

Also bump the GitHub Actions and pre-commit.

<!-- readthedocs-preview docs-community start -->
----
📚 Documentation preview 📚: https://docs-community--105.org.readthedocs.build/

<!-- readthedocs-preview docs-community end -->