### PR TITLE
Link README Discourse badge to discuss.python.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Python Documentation Community
 
 [![Documentation Status](https://readthedocs.org/projects/docs-community/badge/?version=latest)](https://docs-community.readthedocs.io/en/latest/?badge=latest)
-![Discourse](https://img.shields.io/badge/discourse-chat-brightgreen)
+[![Python Discourse Documentation Category](https://img.shields.io/badge/discourse-join_chat-brightgreen.svg)](https://discuss.python.org/c/documentation/26)
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="pep732-circles-dark.png">


### PR DESCRIPTION
Updates the Discourse badge in README to link to the Python Discourse Documentation category, https://discuss.python.org/c/documentation/26. 

Currently, the badge links nowhere (clicking on it takes you to the badge image itself). 

I aimed to match the style of the Discourse badge in CPython's README.

<!-- readthedocs-preview docs-community start -->
----
📚 Documentation preview 📚: https://docs-community--108.org.readthedocs.build/

<!-- readthedocs-preview docs-community end -->