### PR TITLE
Bump MyST-Parser now version > 2.0.0 is out

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 Sphinx
-# myst-parser fixed the docutils warnings. Pinning to current SHA until
-# a new release greater than 2.0.0 is made.
-git+https://github.com/executablebooks/MyST-Parser.git@978e845543b5bcb7af0ff89cac9f798cb8c16ab3
+MyST-Parser
 furo
 sphinx-copybutton
 sphinx-autobuild


### PR DESCRIPTION
v3.0.01 is the latest: https://github.com/executablebooks/MyST-Parser/releases

<!-- readthedocs-preview docs-community start -->
----
📚 Documentation preview 📚: https://docs-community--118.org.readthedocs.build/

<!-- readthedocs-preview docs-community end -->