### PR TITLE
July notes: fix links

### DIFF
--- a/docs/monthly-meeting/2024-07.md
+++ b/docs/monthly-meeting/2024-07.md
@@ -70,8 +70,8 @@ Please take a second to read through it!
   - [Ned] interested in the idea spreadsheet; maybe it can help even offline
   - [Carol] At last PyCon US, Shauna and Melanie tried to make their first docs
     PR, and found some issues in the onboarding process
-    - Shauna: [docs.google.com/document/d/1icjPpmEUH0BRPDwl7oXLkpasvwZoS5io2LyTEhblku0/edit](https://docs.google.com/document/d/1icjPpmEUH0BRPDwl7oXLkpasvwZoS5io2LyTEhblku0/edit)
-    - Melanie: [docs.google.com/document/d/11zxisx5XfYOsrDOn4qd-XUSpDltIOi35qiOO9fDLfnI/edit](https://docs.google.com/document/d/11zxisx5XfYOsrDOn4qd-XUSpDltIOi35qiOO9fDLfnI/edit)
+    - [Shauna](https://docs.google.com/document/d/1icjPpmEUH0BRPDwl7oXLkpasvwZoS5io2LyTEhblku0/edit)
+    - [Melanie](https://docs.google.com/document/d/11zxisx5XfYOsrDOn4qd-XUSpDltIOi35qiOO9fDLfnI/edit)
 
 ### Python Project Documentation
 

--- a/docs/monthly-meeting/2024-07.md
+++ b/docs/monthly-meeting/2024-07.md
@@ -70,8 +70,8 @@ Please take a second to read through it!
   - [Ned] interested in the idea spreadsheet; maybe it can help even offline
   - [Carol] At last PyCon US, Shauna and Melanie tried to make their first docs
     PR, and found some issues in the onboarding process
-    - Shauna: https://docs.google.com/document/d/1icjPpmEUH0BRPDwl7oXLkpasvwZoS5io2LyTEhblku0/edit
-    - Melanie: https://docs.google.com/document/d/11zxisx5XfYOsrDOn4qd-XUSpDltIOi35qiOO9fDLfnI/edit
+    - Shauna: [docs.google.com/document/d/1icjPpmEUH0BRPDwl7oXLkpasvwZoS5io2LyTEhblku0/edit](https://docs.google.com/document/d/1icjPpmEUH0BRPDwl7oXLkpasvwZoS5io2LyTEhblku0/edit)
+    - Melanie: [docs.google.com/document/d/11zxisx5XfYOsrDOn4qd-XUSpDltIOi35qiOO9fDLfnI/edit](https://docs.google.com/document/d/11zxisx5XfYOsrDOn4qd-XUSpDltIOi35qiOO9fDLfnI/edit)
 
 ### Python Project Documentation
 
@@ -111,7 +111,7 @@ Please take a second to read through it!
         gets you to the right place?
       - [Daniele] Documentation on how to read the documentation isn't good
   - Ned to write this down
-      - PR: https://github.com/python/devguide/pull/1344
+      - PR: [python/devguide#1344](https://github.com/python/devguide/pull/1344)
 
 ## Next meeting
 


### PR DESCRIPTION
These weren't clickable links at https://docs-community.readthedocs.io/en/latest/monthly-meeting/2024-07.html

<!-- readthedocs-preview docs-community start -->
----
📚 Documentation preview 📚: https://docs-community--122.org.readthedocs.build/

<!-- readthedocs-preview docs-community end -->