### PR TITLE
Autolink hyperlinks

### DIFF
--- a/docs/monthly-meeting/2023-02.md
+++ b/docs/monthly-meeting/2023-02.md
@@ -103,7 +103,7 @@ Please take a second to read through it!
 ### PEPs styling
 
 * (Hugo) I find the Google font, small size and tight spacing hard to read. The Google font loading causes a big initial layout shift. Trying it out with default fonts and spacing feels more readable, faster loads.
-  * https://hugovk-peps.readthedocs.io/en/sfs/pep-0703/
+  * <https://hugovk-peps.readthedocs.io/en/sfs/pep-0703/>
   * [peps.python.org/pep-0703/](https://peps.python.org/pep-0703/)
   * Originally discussed [discuss.python.org/t/styling-of-peps/13270/34](https://discuss.python.org/t/styling-of-peps/13270/34)
 

--- a/docs/monthly-meeting/2023-02.md
+++ b/docs/monthly-meeting/2023-02.md
@@ -103,7 +103,7 @@ Please take a second to read through it!
 ### PEPs styling
 
 * (Hugo) I find the Google font, small size and tight spacing hard to read. The Google font loading causes a big initial layout shift. Trying it out with default fonts and spacing feels more readable, faster loads.
-  * <https://hugovk-peps.readthedocs.io/en/sfs/pep-0703/>
+  * https://hugovk-peps.readthedocs.io/en/sfs/pep-0703/
   * [peps.python.org/pep-0703/](https://peps.python.org/pep-0703/)
   * Originally discussed [discuss.python.org/t/styling-of-peps/13270/34](https://discuss.python.org/t/styling-of-peps/13270/34)
 

--- a/docs/monthly-meeting/2024-10.md
+++ b/docs/monthly-meeting/2024-10.md
@@ -70,7 +70,7 @@ to read through it!
   - [Melissa] What's the best place for comments? [Ned] Big philosophical questions
     should go to discuss.python.org (maybe a new thread). Putting things in the PR isn't
     bad either. Existing thread at:
-    https://discuss.python.org/t/refactoring-the-devguide-into-a-contribution-guide/63409/14
+    <https://discuss.python.org/t/refactoring-the-devguide-into-a-contribution-guide/63409/14>
   - [Trey] When should the PR be merged? [Ned] When it's useful. In some sense, _this_
     PR will never be merged. [Carol] can periodically rebase the PR to pull in any new
     content.

--- a/docs/monthly-meeting/2024-11.md
+++ b/docs/monthly-meeting/2024-11.md
@@ -77,7 +77,7 @@ to read through it!
     reasonable
   -
 - [Hugo] Move `python-docs-theme` under `cpython` PyPI org:
-  https://discuss.python.org/t/request-python-organisation-on-pypi/26545/10
+  <https://discuss.python.org/t/request-python-organisation-on-pypi/26545/10>
   - Petr: why not `python`?
   - Hugo: because if other projects use the theme, they're
     [borrowing trust and credibility from CPython](https://github.com/python/python-docs-theme).
@@ -87,14 +87,14 @@ to read through it!
   - Mariatta: Or use Discord instead?
   - Group decision: we'll test Discord next month
 - [Carol] History of Dead Batteries page/approach
-  https://discuss.python.org/t/history-of-dead-batteries/68934
+  <https://discuss.python.org/t/history-of-dead-batteries/68934>
   - Hugo: should we have stub pages?
   - Ned: yes, redirect them to a single page with info on replacements. before we got
     404, now we get redirect to homepage instead of 404, which bit less useful
   - Petr: also keep entries for removed functions/classes. better place for porting
     notes than in cramming in What's New.
 - [Carol] API navigation or tables on long pages:
-  https://discuss.python.org/t/summary-tables-as-an-api-overview/68474
+  <https://discuss.python.org/t/summary-tables-as-an-api-overview/68474>
   - [python/cpython#125810](https://github.com/python/cpython/pull/125810) ->
     [docs.python.org/3/library/math.html](https://docs.python.org/3/library/math.html)
   - [python/cpython#126342](https://github.com/python/cpython/pull/126342) ->


### PR DESCRIPTION
Oops, follow on from https://github.com/python/docs-community/pull/135 (and others).

<!-- readthedocs-preview docs-community start -->
----
📚 Documentation preview 📚: https://docs-community--136.org.readthedocs.build/

<!-- readthedocs-preview docs-community end -->