### PR TITLE
Update how minutes archive is displayed

### DIFF
--- a/docs/monthly-meeting/2023-03.md
+++ b/docs/monthly-meeting/2023-03.md
@@ -8,7 +8,7 @@
 - **Calendar event:** (send your e-mail to Mariatta for an invitation)
 - **How to participate:**
   -  Go to [Google Meet](https://meet.google.com/dii-qrzf-wkw) and ask to be let in.
-  -  To edit notes, click the “pencil" or “split view” button on the [HackMD document](https://hackmd.io/@encukou/pydocswg1). You need to log in (e.g. with a GitHub account).
+  -  To edit notes, click the "pencil" or “split view” button on the [HackMD document](https://hackmd.io/@encukou/pydocswg1). You need to log in (e.g. with a GitHub account).
 
 By participating in this meeting, you are agreeing to abide by and uphold the [PSF Code of Conduct](https://www.python.org/psf/codeofconduct/).
 Please take a second to read through it!

--- a/docs/monthly-meeting/2023-05.md
+++ b/docs/monthly-meeting/2023-05.md
@@ -64,7 +64,7 @@ Congrats Ned for the [keynote at PyCon US 2023](https://us.pycon.org/2023/about/
     * Main benefit: multiple admins instead of single-person bottleneck with Netlify.
     * [python/cpython#103843](https://github.com/python/cpython/pull/103843)
 * GH action to update the link from the PR - we don't need one for Netlify
-    * [JDLH thinks this means] GitHub action to update a link to a documentation preview on ReadTheDocs from the Github Pull Request page. We don't need such a preview for the current docs as published at Netlify.
+    * [JDLH thinks this means] GitHub action to update a link to a documentation preview on ReadTheDocs from the GitHub Pull Request page. We don't need such a preview for the current docs as published at Netlify.
     * Example of preview link: Pull Request [#104013, **gh-104010: Separate and improve docs for typing.get_origin and typing.get_args**](https://github.com/python/cpython/pull/104013), contains a link to a preview of the documentation reflecting the Pull Request's effects, at [https://cpython-previews--104013.org.readthedocs.build/en/104013/](https://cpython-previews--104013.org.readthedocs.build/en/104013/).
 * For moving main docs, a few more things are needed, but they're tracked at the RtD side
 * We're using a personal account (Mariatta's). Not ideal. Right now community version of RtD doesn't support multiple owners, there are workarounds. Organizations are only in the commercial version so far.
@@ -102,7 +102,7 @@ Congrats Ned for the [keynote at PyCon US 2023](https://us.pycon.org/2023/about/
     - Manuel: started 3 years ago: have a place to connect with other translators and resources
     - Julien introduced the tools for translation.
     - Create channel for translations
-    - Cristian: It also could be a good idea to have in the main Documentation page (that we will have soon) something like "Wanna help with a translation of these docs? check out this initiatives <list of languages here>"
+    - Cristian: It also could be a good idea to have in the main Documentation page (that we will have soon) something like "Wanna help with a translation of these docs? check out these initiatives <list of languages here>"
     - Ezio: I already brought it up a couple of times, but it would be good to unify the translation infrastructure and tools (see e.g. [python/python-docs-zh-tw#399](https://github.com/python/python-docs-zh-tw/issues/399))
 
 

--- a/docs/monthly-meeting/2023-09.md
+++ b/docs/monthly-meeting/2023-09.md
@@ -90,7 +90,7 @@ Please take a second to read through it!
 
 - [CAM] Quick update on reStructured Data
   - Summary
-    - Mechanism to extract, process and output structured, machine-readible data from the Python docs
+    - Mechanism to extract, process and output structured, machine-readable data from the Python docs
     - Initial focus on deprecations/removals per user requests, then additions/changes and finally other annotations (supported platforms, stable ABI, audit events, etc.)
     - Output a JSON per version and language for tool and API consumption
     - Also output tables of all/specific deprecations/removals (or other changes) in the What's New and on a new dedicated Deprecations/Removals page.

--- a/docs/monthly-meeting/2024-02.md
+++ b/docs/monthly-meeting/2024-02.md
@@ -54,7 +54,7 @@ Please take a second to read through it!
 
     [Ezio] We should also figure out what to do about collapsible sections.
     [Ned] What problem are collapsible sections solving? Do we have too many examples that users will want to ignore? (In my docs I use tabs, but not collapsible sections)
-    [Ezio] They allow us to to add more examples inline without making the page too long and more difficult to navigate, but they don't work with non-HTML builders.
+    [Ezio] They allow us to add more examples inline without making the page too long and more difficult to navigate, but they don't work with non-HTML builders.
 
     [Ned] re. pages being too long, we might switch to having a page for each function
     [Carol] we could run a cron job to count lines

--- a/docs/monthly-meeting/2024-08.md
+++ b/docs/monthly-meeting/2024-08.md
@@ -38,7 +38,7 @@ Please take a second to read through it!
   - In the last 1-2 months, we've been working on the language and version selector. In the current process this is added at build time from a JSON file, RTD does that at serve time with Javascript so even old versions of the docs link to current versions.
   - We've been working to not losing what we already have but also not get rid of RTD features.
   - 3.13 or 3.14 is the version we'll migrate first, to get a feel for the workflow. All other versions will be served by python.org for now. Then we'll migrate one version at a time.
-  - [Trey] Will this enhance the search? [Manuel] There have been many improvements in RTD search lately. Traditionally RTD overwrites Sphinx search entirely with server-side (Elastic Search) search. Now there's a way to choose RTD or Sphinx search from the docs theme. There's also a person who said they're working on the Sphinx sphinx search engine.
+  - [Trey] Will this enhance the search? [Manuel] There have been many improvements in RTD search lately. Traditionally RTD overwrites Sphinx search entirely with server-side (Elastic Search) search. Now there's a way to choose RTD or Sphinx search from the docs theme. There's also a person who said they're working on the Sphinx search engine.
   - [Trey] So there won't be a change on day one.
   - [Carol] For the PR previews, is there an option to link to the most changed file in the PR? [Manuel] We're working on it, don't know the details. The idea is to perform a diff and determine what changed, and link to it directly.
     - Issue: [readthedocs/readthedocs.org#11319](https://github.com/readthedocs/readthedocs.org/issues/11319)

--- a/docs/monthly-meeting/2024-09.md
+++ b/docs/monthly-meeting/2024-09.md
@@ -18,18 +18,18 @@ Please take a second to read through it!
 
 (Name / `@GitHubUsername` *[/ Discord, if different]*)
 
-- Daniele Procida / @EvilDMP
-- Hugo van Kemenade / @hugovk
-- Trey / @treyhunner
+- Daniele Procida / `@EvilDMP`
+- Hugo van Kemenade / `@hugovk`
+- Trey / `@treyhunner`
 - Manuel / `@humitos`
-- Melissa / @melissawm
-- Petr Viktorin / @encukou
+- Melissa / `@melissawm`
+- Petr Viktorin / `@encukou`
 - Ryan / `@ryan-duve`
 
 ## Discussion
 
 - [Hugo]
-  - As a RM, logged into the docs server, and fixed a bunch of stopped jobs
+  - As an RM, logged into the docs server, and fixed a bunch of stopped jobs
   - It would be nice to have 2 cron jobs -- one for HTML (fast), one for PDFs (slow)
   - We have a bus factor for the repo; only 2 active people; we should give access to more people & we should give Adam access to the build server
   - Separately, we want to move HTML to Read the Docs, while keeping the ability to build them separately

--- a/docs/monthly-meeting/2024-10.md
+++ b/docs/monthly-meeting/2024-10.md
@@ -134,7 +134,7 @@ to read through it!
       <https://en.wikipedia.org/wiki/Learning_pathway> -- people can start where they
       need, depending on how much handholding they need etc.
     - [Mariatta] Maybe the first quiz should be “what kind of a learner are you”?
-    - [Carol] Moving away from the tooling: I thing there's a subset of users that use
+    - [Carol] Moving away from the tooling: I think there's a subset of users that use
       the current Python tutorial, others use different ones - Carpentries, ones from
       the scientific ecosystem, Dr.Chuck, Chicago[???], etc. The Carpentries have done a
       great job in the past decade coming up with learning-theory-based tutorials:

--- a/docs/monthly-meeting/2024-11.md
+++ b/docs/monthly-meeting/2024-11.md
@@ -23,13 +23,13 @@ to read through it!
 
 (Name / `@GitHubUsername` _[/ Discord, if different]_)
 
-- Hugo van Kemenade / @hugovk
+- Hugo van Kemenade / `@hugovk` 
 - Mariatta
 - Joe
 - Ned Batchelder / `@nedbat`
 - Trey
 - Daniele
-- Ryan / `ryan-duve`
+- Ryan / `@ryan-duve`
 - Petr / `@encukou`
 
 ## Introductions

--- a/docs/monthly-meeting/index.rst
+++ b/docs/monthly-meeting/index.rst
@@ -5,25 +5,102 @@ Monthly Reports Archive
 
 `Current agenda <https://hackmd.io/@encukou/pydocswg1>`_
 
-Monthly reports in chronological order.
+Monthly reports in reverse chronological order.
 
 .. Around May, reports from the past year should be moved into a section
    to avoid the ToC getting too long.
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Monthly reports
 
-   2022 <2022.rst>
-   2023 <2023.rst>
-   Jan 2024 <2024-01.md>
-   Feb 2024 <2024-02.md>
-   Mar 2024 <2024-03.md>
-   Apr 2024 <2024-04.md>
-   May 2024 <2024-05.md>
-   Jun 2024 <2024-06.md>
-   Jul 2024 <2024-07.md>
-   Aug 2024 <2024-08.md>
-   Sep 2024 <2024-09.md>
-   Oct 2024 <2024-10.md>
-   Nov 2024 <2024-11.md>
+.. raw:: html
+
+    <style>
+        .grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+            gap: 20px;
+        }
+        .grid-year {
+            font-weight: bold;
+            color: #757575;
+            font-size: 1.5em
+        }
+        .grid-item ul {
+            list-style-type: none;
+            padding: 0;
+            margin: 0;
+            color: #5da3e3;
+        }
+        .grid-item ul li a {
+            text-decoration: none;
+            color: #5da3e3;
+        }
+        .grid-item ul li a:hover {
+            text-decoration: underline;
+        }
+    </style>
+
+.. raw:: html
+
+    <div class="grid">
+
+.. raw:: html
+
+        <div class="grid-item">
+            <span class="grid-year">2024</span>
+            <ul>
+                <li><a href="2024-11.html">November, 2024</a></li>
+                <li><a href="2024-10.html">October, 2024</a></li>
+                <li><a href="2024-09.html">September, 2024</a></li>
+                <li><a href="2024-08.html">August, 2024</a></li>
+                <li><a href="2024-07.html">July, 2024</a></li>
+                <li><a href="2024-06.html">June, 2024</a></li>
+                <li><a href="2024-05.html">May, 2024</a></li>
+                <li><a href="2024-04.html">April, 2024</a></li>
+                <li><a href="2024-03.html">March, 2024</a></li>
+                <li><a href="2024-02.html">February, 2024</a></li>
+                <li><a href="2024-01.html">January, 2024</a></li>
+            </ul>
+        </div>
+
+        <div class="grid-item">
+            <span class="grid-year">2023</span>
+            <ul>
+                <li><a href="2023-12.html">December, 2023</a></li>
+                <li><a href="2023-11.html">November, 2023</a></li>
+                <li><a href="2023-10.html">October, 2023</a></li>
+                <li><a href="2023-09.html">September, 2023</a></li>
+                <li><a href="2023-08.html">August, 2023</a></li>
+                <li><a href="2023-07.html">July, 2023</a></li>
+                <li><a href="2023-06.html">June, 2023</a></li>
+                <li><a href="2023-05.html">May, 2023</a></li>
+                <li><a href="2023-04.html">April, 2023</a></li>
+                <li><a href="2023-03.html">March, 2023</a></li>
+                <li><a href="2023-02.html">February, 2023</a></li>
+                <li><a href="2023-01.html">January, 2023</a></li>
+            </ul>
+        </div>
+
+        <div class="grid-item">
+            <span class="grid-year">2022</span>
+            <ul>
+                <li><a href="2022-12.html">December, 2022</a></li>
+                <li><a href="2022-11.html">November, 2022</a></li>
+                <li><a href="2022-10.html">October, 2022</a></li>
+                <li><a href="2022-09.html">September, 2022</a></li>
+                <li><a href="2022-08.html">August, 2022</a></li>
+                <li><a href="2022-07.html">July, 2022</a></li>
+                <li><a href="2022-06.html">June, 2022</a></li>
+                <li><a href="2022-05.html">May, 2022</a></li>
+                <li><a href="2022-04.html">April, 2022</a></li>
+                <li><a href="2022-03.html">March, 2022</a></li>
+                <li><a href="2022-02.html">February, 2022</a></li>
+            </ul>
+        </div>
+
+.. raw:: html
+
+    </div>
+
+
+
+


### PR DESCRIPTION
I was reading the minutes when and the layout is quite weird. Usually such things are in reverse chronological order as the more recent minutes are much more relevant. I have added some html that displays all the minutes (Why were some hidden?) In a grid similar to that of the [Python Boards Minutes archive](https://www.python.org/psf/records/board/minutes/).

![image](https://github.com/user-attachments/assets/5da1c1e2-b213-40fa-ad62-9bdac5f056ae)


<!-- readthedocs-preview docs-community start -->
----
📚 Documentation preview 📚: https://docs-community--137.org.readthedocs.build/

<!-- readthedocs-preview docs-community end -->