### PR TITLE
Update Editorial Board's meeting time

### DIFF
--- a/docs/editorial-board/index.rst
+++ b/docs/editorial-board/index.rst
@@ -9,7 +9,7 @@ The acceptance of :pep:`732` established the Python Documentation Editorial Boar
 Monthly Editorial Board Meetings
 ================================
 
-The Editorial Board's private meetings are held monthly on the second Monday
+The Editorial Board's private meetings are held monthly on the second Tuesday
 at 1:30pm Pacific.
 After each meeting the Editorial Board will post a summary in the
 `python/editorial-board repository <https://github.com/python/editorial-board>`_.

--- a/docs/monthly-meeting/2024-12.md
+++ b/docs/monthly-meeting/2024-12.md
@@ -81,8 +81,8 @@ to read through it!
     the CSS
 
 - Translation dashboard
-  - [m-aciek.github.io/pydocs-translation-dashboard](https://m-aciek.github.io/pydocs-translation-dashboard/)
-  - [m-aciek/pydocs-translation-dashboard](https://github.com/m-aciek/pydocs-translation-dashboard)
+  - [https://python-docs-translations.github.io/dashboard/](https://python-docs-translations.github.io/dashboard/)
+  - [python-docs-translations/dashboard](https://github.com/python-docs-translations/dashboard)
 
 ## Next meeting
 

--- a/docs/monthly-meeting/2025-01.md
+++ b/docs/monthly-meeting/2025-01.md
@@ -53,7 +53,7 @@ This was Sherry's first meeting, introductions were made.
   - This is currently the tutorial and the bugs and functions pages.
   - Brief discussion on this threshold, no strong desire to change.
 - [Adam] Introduce a page for translation progress, like [React's](https://translations.react.dev/), it just needs to be wired up.
-  - There's already [Maciej's page](https://m-aciek.github.io/pydocs-translation-dashboard/)
+  - There's already [Maciej's page](https://python-docs-translations.github.io/dashboard/)
   - Issue created: [docs-community#143](https://github.com/python/docs-community/issues/143)
   - Action: link Maciej's page from the devguide.
   - Action: Add links to contribute.

--- a/docs/monthly-meeting/2025-02.md
+++ b/docs/monthly-meeting/2025-02.md
@@ -71,7 +71,7 @@ Introductions were made.
   - (please note that as of now completion tracking bases on paragraphs number, not
     [words](https://github.com/izimobil/polib/pull/166) number, and may not express the
     translation effort precisely)
-  - [source](https://github.com/m-aciek/pydocs-translation-dashboard/compare/f015a5c401118514c12ae4c75328a201a46171c5...gh-pages)
+  - [source](https://github.com/python-docs-translations/dashboard/compare/f015a5c401118514c12ae4c75328a201a46171c5...gh-pages)
 
 ## Discussion
 


### PR DESCRIPTION
We moved to the second Tuesday of the month instead of Monday.

<!-- readthedocs-preview docs-community start -->
----
📚 Documentation preview 📚: https://docs-community--151.org.readthedocs.build/

<!-- readthedocs-preview docs-community end -->