### PR TITLE
Fix linkcheck

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,5 +62,7 @@ linkcheck_ignore = [
     r"https://[a-zA-Z0-9.-]+\.org\.readthedocs\.build/[a-zA-Z0-9.-]+/[a-zA-Z0-9.-]+/",
     # Deleted pages:
     r"https://plausible\.io/share/hugovk-cpython\.readthedocs\.io\?auth=XDF9fK3EB2dEHCr4sC9hn",
+    r"https://plausible.io/docs.python.org",
+    r"https://plausible.io/packaging.python.org",
     r"https://us.pycon.org/2024/registration/category/4",
 ]


### PR DESCRIPTION
https://plausible.io/docs.python.org and https://plausible.io/packaging.python.org have move to self-hosted at https://analytics.python.org/docs.python.org and https://analytics.python.org/packaging.python.org.