### PR TITLE
Fix the wording of sentences in index.rst

### DIFF
--- a/docs/community/index.rst
+++ b/docs/community/index.rst
@@ -6,12 +6,13 @@ Documentation Community Team
 
 Open for all Python community members to participate.
 
-The Documentation Team will be contributors to documentation who participate
-regularly to CPython documentation and monthly meetings (synchronously or
-asynchronously). A goal of this team will be to build a global community
-around CPython documentation.
+The Documentation Team consists of contributors who regularly participate in
+`CPython documentation <https://docs.python.org/3/>`_ work and monthly meetings
+(either synchronously or asynchronously).
+A goal of this team is to build a global community around CPython documentation.
 
-The Documentation Community Team has a Code of Conduct
+The Documentation Community Team follows the
+`PSF Code of Conduct <https://policies.python.org/python.org/code-of-conduct/>`_.
 
 .. toctree::
 


### PR DESCRIPTION
The team now exists, so the future tense is incorrect. It seems the second sentence is cut off, I assume what I changed it to was intended, as I can not find any other such document.

<!-- readthedocs-preview docs-community start -->
----
📚 Documentation preview 📚: https://docs-community--167.org.readthedocs.build/

<!-- readthedocs-preview docs-community end -->