### PR TITLE
Improve link to docs issues in CPython

### DIFF
--- a/docs/community/community-guide.md
+++ b/docs/community/community-guide.md
@@ -30,4 +30,5 @@ questions, or just as a place where we can inspire each other.
 ## How can I help?
 
 Read the devguide's section on documentation.
-Visit the Python repo's GitHub issues and look for [issues tagged with "docs"](https://github.com/python/cpython/labels/docs).
+Visit the Python repo's GitHub issues and look for
+[issues tagged with "docs"](https://github.com/python/cpython/issues?q=state%3Aopen%20is%3Aissue%20label%3Adocs).


### PR DESCRIPTION
Filter out PRs with the label, so that we are only left with _"issues tagged with "docs""_.

<!-- readthedocs-preview docs-community start -->
----
📚 Documentation preview 📚: https://docs-community--172.org.readthedocs.build/

<!-- readthedocs-preview docs-community end -->