### PR TITLE
Exclude `monthly-meeting` folder from linkcheck

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,3 +67,8 @@ linkcheck_ignore = [
     r"https://plausible.io/packaging.python.org",
     r"https://us.pycon.org/2024/registration/category/4",
 ]
+
+# A list of document names to exclude from linkcheck
+linkcheck_exclude_documents = [
+    r"monthly-meeting/.*",
+]


### PR DESCRIPTION


<!-- readthedocs-preview docs-community start -->
----
📚 Documentation preview 📚: https://docs-community--177.org.readthedocs.build/

<!-- readthedocs-preview docs-community end -->