### PR TITLE
Add extension to generate a table of future meeting dates and times

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.14"
 
 python:
   install:

--- a/docs/community/monthly-meeting.rst
+++ b/docs/community/monthly-meeting.rst
@@ -5,9 +5,7 @@ Documentation Community Monthly Meetings
 
 Monthly meetings are held on the first Tuesday of the month
 on the `Discord server <https://discord.gg/sMWqvzXvde>`_ and last one hour.
-Check the agenda or Discourse announcement to verify the start time.
-
-Upcoming meetings:
+Upcoming meeting dates and times:
 
 .. meeting-dates::
 
@@ -34,6 +32,7 @@ Meetings follow the pattern:
 +-----------------+--------------+--------------+
 | November-March  | 20:00 UTC    | 17:00 UTC    |
 +-----------------+--------------+--------------+
+
 
 Minutes template
 ----------------

--- a/docs/community/monthly-meeting.rst
+++ b/docs/community/monthly-meeting.rst
@@ -7,13 +7,11 @@ Monthly meetings are held on the first Tuesday of the month
 on the `Discord server <https://discord.gg/sMWqvzXvde>`_ and last one hour.
 Check the agenda or Discourse announcement to verify the start time.
 
-+-----------------+--------------+--------------+
-| Period          | Even months  | Odd months   |
-+=================+==============+==============+
-| April-October   | 19:00 UTC    | 16:00 UTC    |
-+-----------------+--------------+--------------+
-| November-March  | 20:00 UTC    | 17:00 UTC    |
-+-----------------+--------------+--------------+
+Upcoming meetings:
+
+.. meeting-dates::
+
+`Download calendar (ICS) </docs-community-meetings.ics>`_
 
 The agenda and later the meeting minutes are written in the `HackMD <https://hackmd.io/@encukou/pydocswg1>`_.
 To edit notes, click the “pencil” or “split view” button on the `HackMD Document <https://hackmd.io/@encukou/pydocswg1>`_.
@@ -27,6 +25,15 @@ By participating in meetings, you are agreeing to abide by and uphold the
 `PSF Code of Conduct <https://policies.python.org/python.org/code-of-conduct/>`_.
 Please take a second to read through it!
 
+Meetings follow the pattern:
+
++-----------------+--------------+--------------+
+| Period          | Even months  | Odd months   |
++=================+==============+==============+
+| April-October   | 19:00 UTC    | 16:00 UTC    |
++-----------------+--------------+--------------+
+| November-March  | 20:00 UTC    | 17:00 UTC    |
++-----------------+--------------+--------------+
 
 Minutes template
 ----------------

--- a/docs/community/monthly-meeting.rst
+++ b/docs/community/monthly-meeting.rst
@@ -11,7 +11,7 @@ Upcoming meetings:
 
 .. meeting-dates::
 
-`Download calendar (ICS) </docs-community-meetings.ics>`_
+`Download iCalendar file </docs-community-meetings.ics>`_
 
 The agenda and later the meeting minutes are written in the `HackMD <https://hackmd.io/@encukou/pydocswg1>`_.
 To edit notes, click the “pencil” or “split view” button on the `HackMD Document <https://hackmd.io/@encukou/pydocswg1>`_.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,6 +74,9 @@ linkcheck_ignore = [
     r"https://plausible.io/docs.python.org",
     r"https://plausible.io/packaging.python.org",
     r"https://us.pycon.org/2024/registration/category/4",
+    r"https://arewemeetingyet.com/.*",
+    # Generated at build time
+    r"/docs-community-meetings.ics",
 ]
 
 # A list of document names to exclude from linkcheck

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,8 +74,9 @@ linkcheck_ignore = [
     r"https://plausible.io/docs.python.org",
     r"https://plausible.io/packaging.python.org",
     r"https://us.pycon.org/2024/registration/category/4",
+    # Have redirects:
     r"https://arewemeetingyet.com/.*",
-    # Generated at build time
+    # Generated at build time:
     r"/docs-community-meetings.ics",
 ]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,10 +11,16 @@ author = "Documentation Team"
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 # A list of strings that are module names of Sphinx extensions
+import os
+import sys
+
+sys.path.append(os.path.abspath("tools/"))
+
 extensions = [
     "sphinx_copybutton",
     "sphinx.ext.intersphinx",
     "myst_parser",
+    "meeting_dates",
 ]
 
 myst_enable_extensions = ["linkify"]

--- a/docs/tools/meeting_dates.py
+++ b/docs/tools/meeting_dates.py
@@ -87,7 +87,7 @@ def generate_ics(app, exception):
         lines += [
             "BEGIN:VEVENT",
             f"UID:{start.strftime('%Y%m%dT%H%M%SZ')}@python-docs-community",
-            f"DTSTAMP:{dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")}",
+            f"DTSTAMP:{dt.datetime.now(dt.timezone.utc).strftime('%Y%m%dT%H%M%SZ')}",
             f"DTSTART:{start.strftime('%Y%m%dT%H%M%SZ')}",
             f"DTEND:{end.strftime('%Y%m%dT%H%M%SZ')}",
             "SUMMARY:Docs Community Meeting",

--- a/docs/tools/meeting_dates.py
+++ b/docs/tools/meeting_dates.py
@@ -41,11 +41,10 @@ class MeetingDatesDirective(SphinxDirective):
 
     def run(self):
         today = dt.date.today()
-        meetings = upcoming_meetings(today)
-        self.env.meeting_dates = meetings
+        self.env.meeting_dates = upcoming_meetings(today)
 
         bullets = nodes.bullet_list()
-        for date, hour in meetings:
+        for date, hour in self.env.meeting_dates:
             item = nodes.list_item()
             text = f"{date.strftime('%B %d, %Y')} - {hour:02d}:00 UTC"
             url = f"https://arewemeetingyet.com/UTC/{date.isoformat()}/{hour}:00/Docs Community Meeting"
@@ -63,14 +62,12 @@ def generate_ics(app, exception):
     if exception:
         return
 
-    meetings = app.env.meeting_dates
-
     lines = [
         "BEGIN:VCALENDAR",
         "VERSION:2.0",
         "PRODID:-//Python Docs Community//Meeting Dates//EN",
     ]
-    for date, hour in meetings:
+    for date, hour in app.env.meeting_dates:
         start = dt.datetime(date.year, date.month, date.day, hour, 0, 0)
         end = start + dt.timedelta(hours=1)
         lines += [
@@ -86,8 +83,7 @@ def generate_ics(app, exception):
         "\r\n".join(lines) + "\r\n"
     )  # Required by spec for some reason: https://datatracker.ietf.org/doc/html/rfc5545#section-3.1
 
-    path = os.path.join(app.outdir, "docs-community-meetings.ics")
-    with open(path, "w") as f:
+    with open(os.path.join(app.outdir, "docs-community-meetings.ics"), "w") as f:
         f.write(ics)
 
 

--- a/docs/tools/meeting_dates.py
+++ b/docs/tools/meeting_dates.py
@@ -40,11 +40,8 @@ class MeetingDatesDirective(SphinxDirective):
     has_content = False
 
     def run(self):
-        today = dt.date.today()
-        self.env.meeting_dates = upcoming_meetings(today)
-
         bullets = nodes.bullet_list()
-        for date, hour in self.env.meeting_dates:
+        for date, hour in upcoming_meetings(dt.date.today()):
             item = nodes.list_item()
             text = f"{date.strftime('%B %d, %Y')} - {hour:02d}:00 UTC"
             url = f"https://arewemeetingyet.com/UTC/{date.isoformat()}/{hour}:00/Docs Community Meeting"
@@ -67,7 +64,7 @@ def generate_ics(app, exception):
         "VERSION:2.0",
         "PRODID:-//Python Docs Community//Meeting Dates//EN",
     ]
-    for date, hour in app.env.meeting_dates:
+    for date, hour in upcoming_meetings(dt.date.today()):
         start = dt.datetime(date.year, date.month, date.day, hour, 0, 0)
         end = start + dt.timedelta(hours=1)
         lines += [

--- a/docs/tools/meeting_dates.py
+++ b/docs/tools/meeting_dates.py
@@ -22,10 +22,10 @@ def first_tuesday(year, month):
     return first + dt.timedelta(days=days_ahead)
 
 
-def upcoming_meetings(today):
+def upcoming_meetings(today, count):
     meetings = []
     year, month = today.year, today.month
-    while len(meetings) < 6:  # Max of six meeting entries
+    while len(meetings) < count:
         meeting_date = first_tuesday(year, month)
         if meeting_date >= today:
             meetings.append((meeting_date, utc_hour(meeting_date)))
@@ -36,12 +36,27 @@ def upcoming_meetings(today):
     return meetings
 
 
+def past_meetings(today, count):
+    meetings = []
+    year, month = today.year, today.month
+    while len(meetings) < count:
+        meeting_date = first_tuesday(year, month)
+        if meeting_date < today:
+            meetings.append((meeting_date, utc_hour(meeting_date)))
+        month -= 1
+        if month < 1:
+            month = 12
+            year -= 1
+    meetings.reverse()
+    return meetings
+
+
 class MeetingDatesDirective(SphinxDirective):
     has_content = False
 
     def run(self):
         bullets = nodes.bullet_list()
-        for date, hour in upcoming_meetings(dt.date.today()):
+        for date, hour in upcoming_meetings(dt.date.today(), 6):
             item = nodes.list_item()
             text = f"{date.strftime('%B %d, %Y')} - {hour:02d}:00 UTC"
             url = f"https://arewemeetingyet.com/UTC/{date.isoformat()}/{hour}:00/Docs Community Meeting"
@@ -64,11 +79,15 @@ def generate_ics(app, exception):
         "VERSION:2.0",
         "PRODID:-//Python Docs Community//Meeting Dates//EN",
     ]
-    for date, hour in upcoming_meetings(dt.date.today()):
+    today = dt.date.today()
+    meetings = past_meetings(today, 12) + upcoming_meetings(today, 12)
+    for date, hour in meetings:
         start = dt.datetime(date.year, date.month, date.day, hour, 0, 0)
         end = start + dt.timedelta(hours=1)
         lines += [
             "BEGIN:VEVENT",
+            f"UID:{start.strftime('%Y%m%dT%H%M%SZ')}@python-docs-community",
+            f"DTSTAMP:{dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")}",
             f"DTSTART:{start.strftime('%Y%m%dT%H%M%SZ')}",
             f"DTEND:{end.strftime('%Y%m%dT%H%M%SZ')}",
             "SUMMARY:Docs Community Meeting",

--- a/docs/tools/meeting_dates.py
+++ b/docs/tools/meeting_dates.py
@@ -1,0 +1,97 @@
+"""Sphinx extension to generate a list of upcoming meeting dates."""
+
+import datetime as dt
+import os
+
+from docutils import nodes
+from sphinx.util.docutils import SphinxDirective
+
+
+def utc_hour(date):
+    if 4 <= date.month <= 10:
+        # Daylight saving time in Europe and the US
+        return 19 if date.month % 2 == 0 else 16
+    else:
+        # Winter time in Europe and the US
+        return 20 if date.month % 2 == 0 else 17
+
+
+def first_tuesday(year, month):
+    first = dt.date(year, month, 1)
+    days_ahead = (1 - first.weekday()) % 7
+    return first + dt.timedelta(days=days_ahead)
+
+
+def upcoming_meetings(today):
+    meetings = []
+    year, month = today.year, today.month
+    while len(meetings) < 6:  # Max of six meeting entries
+        meeting_date = first_tuesday(year, month)
+        if meeting_date >= today:
+            meetings.append((meeting_date, utc_hour(meeting_date)))
+        month += 1
+        if month > 12:
+            month = 1
+            year += 1
+    return meetings
+
+
+class MeetingDatesDirective(SphinxDirective):
+    has_content = False
+
+    def run(self):
+        today = dt.date.today()
+        meetings = upcoming_meetings(today)
+        self.env.meeting_dates = meetings
+
+        bullets = nodes.bullet_list()
+        for date, hour in meetings:
+            item = nodes.list_item()
+            text = f"{date.strftime('%B %d, %Y')} - {hour:02d}:00 UTC"
+            url = f"https://arewemeetingyet.com/UTC/{date.isoformat()}/{hour}:00/Docs Community Meeting"
+
+            paragraph = nodes.paragraph()
+            ref = nodes.reference("", text, refuri=url)
+            paragraph += ref
+            item += paragraph
+            bullets += item
+
+        return [bullets]
+
+
+def generate_ics(app, exception):
+    if exception:
+        return
+
+    meetings = app.env.meeting_dates
+
+    lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//Python Docs Community//Meeting Dates//EN",
+    ]
+    for date, hour in meetings:
+        start = dt.datetime(date.year, date.month, date.day, hour, 0, 0)
+        end = start + dt.timedelta(hours=1)
+        lines += [
+            "BEGIN:VEVENT",
+            f"DTSTART:{start.strftime('%Y%m%dT%H%M%SZ')}",
+            f"DTEND:{end.strftime('%Y%m%dT%H%M%SZ')}",
+            "SUMMARY:Docs Community Meeting",
+            f"URL:https://arewemeetingyet.com/UTC/{date.isoformat()}/{hour}:00/Docs Community Meeting",
+            "END:VEVENT",
+        ]
+    lines += ["END:VCALENDAR"]
+    ics = (
+        "\r\n".join(lines) + "\r\n"
+    )  # Required by spec for some reason: https://datatracker.ietf.org/doc/html/rfc5545#section-3.1
+
+    path = os.path.join(app.outdir, "docs-community-meetings.ics")
+    with open(path, "w") as f:
+        f.write(ics)
+
+
+def setup(app):
+    app.add_directive("meeting-dates", MeetingDatesDirective)
+    app.connect("build-finished", generate_ics)
+    return {"version": "1.0", "parallel_read_safe": True}

--- a/docs/tools/meeting_dates.py
+++ b/docs/tools/meeting_dates.py
@@ -77,7 +77,9 @@ def generate_ics(app, exception):
     lines = [
         "BEGIN:VCALENDAR",
         "VERSION:2.0",
-        "PRODID:-//Python Docs Community//Meeting Dates//EN",
+        "PRODID:-//Python Docs Community//Meeting dates//EN",
+        "X-WR-CALDESC:Python docs community meeting dates from https://docs-community.readthedocs.io/",
+        "X-WR-CALNAME:Python docs community meeting dates",
     ]
     today = dt.date.today()
     meetings = past_meetings(today, 12) + upcoming_meetings(today, 12)
@@ -95,9 +97,7 @@ def generate_ics(app, exception):
             "END:VEVENT",
         ]
     lines += ["END:VCALENDAR"]
-    ics = (
-        "\r\n".join(lines) + "\r\n"
-    )  # Required by spec for some reason: https://datatracker.ietf.org/doc/html/rfc5545#section-3.1
+    ics = "\r\n".join(lines) + "\r\n"
 
     with open(os.path.join(app.outdir, "docs-community-meetings.ics"), "w") as f:
         f.write(ics)

--- a/docs/tools/meeting_dates.py
+++ b/docs/tools/meeting_dates.py
@@ -77,9 +77,9 @@ def generate_ics(app, exception):
     lines = [
         "BEGIN:VCALENDAR",
         "VERSION:2.0",
-        "PRODID:-//Python Docs Community//Meeting dates//EN",
-        "X-WR-CALDESC:Python docs community meeting dates from https://docs-community.readthedocs.io/",
-        "X-WR-CALNAME:Python docs community meeting dates",
+        "PRODID:-//Python Docs WG//Meeting dates//EN",
+        "X-WR-CALDESC:Python Docs WG meetings from https://docs-community.readthedocs.io/",
+        "X-WR-CALNAME:Python Docs WG meetings",
     ]
     today = dt.date.today()
     meetings = past_meetings(today, 12) + upcoming_meetings(today, 12)
@@ -92,8 +92,8 @@ def generate_ics(app, exception):
             f"DTSTAMP:{dt.datetime.now(dt.timezone.utc).strftime('%Y%m%dT%H%M%SZ')}",
             f"DTSTART:{start.strftime('%Y%m%dT%H%M%SZ')}",
             f"DTEND:{end.strftime('%Y%m%dT%H%M%SZ')}",
-            "SUMMARY:Docs Community Meeting",
-            f"URL:https://arewemeetingyet.com/UTC/{date.isoformat()}/{hour}:00/Docs Community Meeting",
+            "SUMMARY:Python Docs WG",
+            f"URL:https://arewemeetingyet.com/UTC/{date.isoformat()}/{hour}:00/Python Docs WG meeting",
             "END:VEVENT",
         ]
     lines += ["END:VCALENDAR"]


### PR DESCRIPTION
This expands a little on https://github.com/python/docs-community/pull/185, adding an extension to automatically generate a list of upcoming meetings, and an iCal.

<!-- readthedocs-preview docs-community start -->
----
📚 Documentation preview 📚: https://docs-community--186.org.readthedocs.build/community/monthly-meeting.html

<!-- readthedocs-preview docs-community end -->