### PR TITLE
Don't link to deprecated Discord event in the iCal

### DIFF
--- a/docs/tools/meeting_dates.py
+++ b/docs/tools/meeting_dates.py
@@ -92,9 +92,9 @@ def generate_ics(app, exception):
             f"DTSTAMP:{dt.datetime.now(dt.timezone.utc).strftime('%Y%m%dT%H%M%SZ')}",
             f"DTSTART:{start.strftime('%Y%m%dT%H%M%SZ')}",
             f"DTEND:{end.strftime('%Y%m%dT%H%M%SZ')}",
-            "SUMMARY:Python Docs WG",
+            "SUMMARY:Python Docs WG monthly meeting",
             "DESCRIPTION:Agenda: https://hackmd.io/@encukou/pydocswg1",
-            " \\nDiscord event: https://discord.gg/yhvN2ECXSM?event=1389130476555337908",
+            " \\nDiscord channel: https://discord.gg/yhvN2ECXSM",
             "END:VEVENT",
         ]
     lines += ["END:VCALENDAR"]


### PR DESCRIPTION
As currently the automatically generated events are looking like: 
<img width="685" height="296" alt="image" src="https://github.com/user-attachments/assets/53ab4f21-9811-4906-a41e-cd8cc44bf0cd" />

